### PR TITLE
fix: resolve 6 skill versioning and installation issues

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -281,7 +281,7 @@ export async function getVersionDiff(
 ): Promise<VersionDiffResult> {
   const encoded = [encodeURIComponent(from), encodeURIComponent(to)];
   return apiRequest<VersionDiffResult>(
-    `${skillApiPath(name)}/versions?from=${encoded[0]}&to=${encoded[1]}`,
+    `${skillApiPath(name)}/versions/diff?from=${encoded[0]}&to=${encoded[1]}`,
   );
 }
 
@@ -296,6 +296,7 @@ export async function getVersionDiff(
 export async function reportInstall(
   skillName: string,
   repoUrl?: string,
+  version?: string,
 ): Promise<void> {
   const verbose = process.env.VSKILL_DEBUG === "1";
   try {
@@ -317,6 +318,7 @@ export async function reportInstall(
               },
               body: JSON.stringify({
                 ...(repoUrl ? { repoUrl } : {}),
+                ...(version ? { version } : {}),
                 source: "cli",
                 platform: process.platform,
                 cliVersion: VERSION,
@@ -412,7 +414,7 @@ export async function checkUpdates(
 }
 
 export async function reportInstallBatch(
-  skills: Array<{ skillName: string; repoUrl?: string }>,
+  skills: Array<{ skillName: string; repoUrl?: string; version?: string }>,
 ): Promise<void> {
   const verbose = process.env.VSKILL_DEBUG === "1";
   try {

--- a/src/commands/pin.ts
+++ b/src/commands/pin.ts
@@ -49,6 +49,14 @@ export async function pinCommand(
   writeLockfile(lock);
 
   console.log(green(`Pinned ${bold(skill)} at ${bold(pinVersion)}`));
+  if (version && version !== entry.version) {
+    console.log(
+      dim(`Note: installed version is ${entry.version}. Pin prevents future updates past ${pinVersion}.`),
+    );
+    console.log(
+      dim(`To install version ${pinVersion}, use: ${cyan(`vskill install ${skill}@${pinVersion}`)}`),
+    );
+  }
 }
 
 export async function unpinCommand(skill: string): Promise<void> {

--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -2,7 +2,7 @@
 // vskill update -- update installed skills
 // ---------------------------------------------------------------------------
 
-import { unlinkSync } from "node:fs";
+import { unlinkSync, rmdirSync, readdirSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { readLockfile, writeLockfile } from "../lockfile/index.js";
 import { ensureSkillMdNaming } from "../installer/migrate.js";
@@ -46,6 +46,28 @@ function cleanupGhostFiles(
       } catch {
         // File may already be missing — ignore
       }
+    }
+  }
+  // Clean up empty directories left behind
+  const dirsToCheck = new Set<string>();
+  for (const file of oldFiles) {
+    if (!newSet.has(file)) {
+      const dir = resolve(skillDir, file, "..");
+      if (dir !== resolvedBase && dir.startsWith(resolvedBase + "/")) {
+        dirsToCheck.add(dir);
+      }
+    }
+  }
+  // Remove empty dirs bottom-up
+  const sortedDirs = [...dirsToCheck].sort((a, b) => b.length - a.length);
+  for (const dir of sortedDirs) {
+    try {
+      const entries = readdirSync(dir);
+      if (entries.length === 0) {
+        rmdirSync(dir);
+      }
+    } catch {
+      // Directory may already be removed — ignore
     }
   }
 }
@@ -183,7 +205,7 @@ export async function updateCommand(
 
       // 6. Resolve version
       const newVersion = resolveVersion({
-        serverVersion: result.version,
+        serverVersion: parsed.type === "registry" ? result.version : undefined,
         frontmatterVersion: extractFrontmatterVersion(result.content),
         currentVersion: entry.version,
         hashChanged: true,

--- a/src/lockfile/migration.ts
+++ b/src/lockfile/migration.ts
@@ -12,7 +12,12 @@ import type { SkillLockEntry, VskillLock } from "./types.js";
 export function migrateLockEntry(entry: SkillLockEntry): SkillLockEntry {
   const version =
     !entry.version || entry.version === "0.0.0" ? "1.0.0" : entry.version;
-  return { ...entry, version };
+
+  // Normalize tier values from external tools (e.g., specweave migration uses "free")
+  const validTiers = ["CERTIFIED", "VERIFIED", "SCANNED"];
+  const tier = validTiers.includes(entry.tier) ? entry.tier : "VERIFIED";
+
+  return { ...entry, version, tier };
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes 6 issues discovered during a cross-repo ecosystem review of the skill versioning and installation flow across vskill, vskill-platform, and specweave.

- **Version priority chain (#4):** `resolveVersion` in update.ts now only passes `serverVersion` for registry sources, preventing double-application of frontmatter version for GitHub/marketplace sources where `result.version` is already the frontmatter value
- **Pin command UX (#5):** `vskill pin skill 1.0.0` now warns when the pinned version differs from the installed version, guiding users to `vskill install` for actual downgrade
- **Ghost directory cleanup (#6):** `cleanupGhostFiles` now removes empty directories left behind after file deletion during version updates (previously only unlinked files, leaving orphaned dirs)
- **Diff endpoint path (#8):** `getVersionDiff` now uses `/versions/diff?from=...&to=...` instead of query params on `/versions`, matching the platform's dedicated diff handler
- **Install version tracking (#14):** `reportInstall` and `reportInstallBatch` now accept an optional `version` parameter for version-level install analytics
- **Lockfile tier migration (#16):** `migrateLockEntry` now normalizes invalid tier values (e.g. `"free"` from specweave migration) to `"VERIFIED"` for cross-tool compatibility

## Files changed

| File | Change |
|------|--------|
| `src/commands/update.ts` | Fix version priority, add ghost dir cleanup |
| `src/commands/pin.ts` | Add version mismatch warning |
| `src/api/client.ts` | Fix diff endpoint path, add version to install tracking |
| `src/lockfile/migration.ts` | Add tier normalization |

## Test plan

- [ ] `vskill update` on a GitHub-sourced skill uses frontmatter version, not server version
- [ ] `vskill update` on a registry-sourced skill still uses server version
- [ ] `vskill pin skill 1.0.0` when installed at 1.0.3 shows warning about version mismatch
- [ ] `vskill update` after removing `agents/` files from a new version cleans up empty `agents/` directory
- [ ] `vskill versions skill --diff` hits `/versions/diff` endpoint correctly
- [ ] Lockfile with `tier: "free"` is migrated to `"VERIFIED"` on read

https://claude.ai/code/session_01RUfe8W1tSkUinPA2C8H8rr