### PR TITLE
0703 hotfix: Skill Studio create flow — 6 bugs fixed

### DIFF
--- a/e2e/0703-create-flow-hotfix.spec.ts
+++ b/e2e/0703-create-flow-hotfix.spec.ts
@@ -1,0 +1,215 @@
+// ---------------------------------------------------------------------------
+// 0703 — Studio create-flow hotfix E2E verification.
+//
+// Six bugs shipped in the "+ New Skill → Generate with AI" flow. Each scenario
+// below exercises one of the shipped fixes against the real eval-server SPA
+// (webServer from playwright.config.ts serves e2e/fixtures at port 3077).
+//
+// SCOPE: verification only — the source fixes are already shipped and unit-
+// tested. If a scenario fails here it's either a genuine regression or a
+// test-setup mistake; the SPEC is fixed, not the source.
+// ---------------------------------------------------------------------------
+
+import { test, expect, type Page } from "@playwright/test";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function gotoStudio(page: Page) {
+  await page.goto("/");
+  await page.waitForSelector("[data-testid='sidebar']", { timeout: 10_000 });
+}
+
+async function openCreateModal(page: Page) {
+  const trigger = page.locator("[data-slot='create-skill-button']");
+  await expect(trigger).toBeVisible();
+  await trigger.click();
+  // Modal step 1 header
+  await expect(page.getByRole("heading", { name: "Create a skill" })).toBeVisible();
+}
+
+async function advanceToStep2(page: Page) {
+  // The only "Continue →" button on step 1.
+  await page.getByRole("button", { name: /Continue/ }).click();
+  // Step 2 header
+  await expect(page.getByRole("heading", { name: "Name and describe" })).toBeVisible();
+}
+
+// ---------------------------------------------------------------------------
+// Scenario 1 — Prompt pre-fills from modal (AC-US1-01 / US-US2-05)
+// ---------------------------------------------------------------------------
+test.describe("0703 — prompt pre-fill from modal", () => {
+  test("typing description in modal seeds the Generate page textarea and enables the button", async ({
+    page,
+  }) => {
+    await gotoStudio(page);
+    await openCreateModal(page);
+    await advanceToStep2(page);
+
+    // Fill skill name + description on step 2
+    const skillInput = page.locator("input[placeholder='my-new-skill']");
+    await skillInput.fill("hotfix-demo-a");
+    const descTextarea = page.locator("textarea[placeholder='Does a thing when Claude needs X']");
+    await descTextarea.fill("Greets the user by name");
+
+    // Click "Generate with AI" — should navigate to /#/create with params
+    await page.getByRole("button", { name: /Generate with AI/ }).click();
+
+    // Wait for the Create page to appear
+    await expect(page.getByRole("heading", { name: "Create a New Skill" })).toBeVisible({
+      timeout: 10_000,
+    });
+
+    // The prompt textarea on the AI-mode page has this placeholder:
+    const promptTextarea = page.locator(
+      "textarea[placeholder*='A skill that helps format SQL queries']",
+    );
+    await expect(promptTextarea).toBeVisible();
+    await expect(promptTextarea).toHaveValue("Greets the user by name");
+
+    // The Generate Skill button must NOT be disabled
+    const genBtn = page.getByRole("button", { name: /Generate Skill/ });
+    await expect(genBtn).toBeVisible();
+    await expect(genBtn).toBeEnabled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Scenario 2 — Duplicate skill name blocked at modal (AC-US2-04)
+// The fixture e2e/fixtures/skills/hotfix-dup-test/ is pre-seeded on disk.
+// ---------------------------------------------------------------------------
+test.describe("0703 — duplicate skill name pre-check", () => {
+  test("modal shows 'already exists' error and does NOT navigate", async ({ page }) => {
+    await gotoStudio(page);
+    const initialHash = await page.evaluate(() => window.location.hash);
+
+    await openCreateModal(page);
+    await advanceToStep2(page);
+
+    await page.locator("input[placeholder='my-new-skill']").fill("hotfix-dup-test");
+
+    // Click Generate with AI — probe should return exists:true and keep us on the modal.
+    await page.getByRole("button", { name: /Generate with AI/ }).click();
+
+    // Wait for the error text to appear inline in the modal.
+    const errorRegion = page.getByText(/already exists/i);
+    await expect(errorRegion).toBeVisible({ timeout: 5_000 });
+
+    // Hash must NOT have flipped to #/create.
+    const hashAfter = await page.evaluate(() => window.location.hash);
+    expect(hashAfter).not.toContain("/create");
+    // (Should still be the home/same hash we started from.)
+    expect(hashAfter === initialHash || hashAfter === "" || hashAfter === "#/").toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Scenario 3 — Model picker no-overlap (AC-US3-01)
+// ---------------------------------------------------------------------------
+test.describe("0703 — ModelList row layout", () => {
+  test("Claude Code pane rows are >= 44px tall and only ONE row shows 'routing to'", async ({
+    page,
+  }) => {
+    await gotoStudio(page);
+
+    // Open the agent-model picker via its trigger button.
+    const trigger = page.locator("[data-testid='agent-model-picker-trigger']");
+    await expect(trigger).toBeVisible();
+    await trigger.click();
+    await expect(page.locator("[data-testid='agent-model-picker-popover']")).toBeVisible();
+
+    // The ModelList pane is rendered only after an agent row is focused.
+    // Hover the claude-cli (Claude Code) row to populate the ModelList.
+    const claudeRow = page.locator(
+      "[data-testid='agent-row-claude-cli'], [data-testid='agent-row-claude-code']",
+    ).first();
+    await expect(claudeRow).toBeVisible();
+    await claudeRow.hover();
+
+    // Wait for at least one model row to appear.
+    await page
+      .locator("button[data-testid^='model-row-']:not([data-testid$='-resolved'])")
+      .first()
+      .waitFor({ timeout: 5_000 });
+
+    // Stricter selector: top-level rows end in the model id (no -resolved suffix).
+    const topLevelRows = page.locator(
+      "button[data-testid^='model-row-']:not([data-testid$='-resolved'])",
+    );
+    const rowCount = await topLevelRows.count();
+    expect(rowCount).toBeGreaterThanOrEqual(3); // opus / sonnet / haiku
+
+    for (let i = 0; i < rowCount; i++) {
+      const row = topLevelRows.nth(i);
+      const box = await row.boundingBox();
+      expect(box, `row ${i} has no bounding box`).not.toBeNull();
+      expect(
+        box!.height,
+        `row ${i} height ${box!.height}px < 44`,
+      ).toBeGreaterThanOrEqual(44);
+    }
+
+    // Exactly one row should carry the -resolved sub-line (the one whose alias
+    // matches the server's resolvedModel). Eval-server defaults to "sonnet" so
+    // the match lives on the sonnet row.
+    const resolvedCount = await page.locator("[data-testid$='-resolved']").count();
+    expect(resolvedCount).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Scenario 4 — Direct /#/create navigation works (route regression guard)
+// ---------------------------------------------------------------------------
+test.describe("0703 — direct /#/create route", () => {
+  test("navigating to /#/create?mode=standalone&…&description=… renders the page + seeds prompt", async ({
+    page,
+  }) => {
+    await page.goto(
+      "/#/create?mode=standalone&skillName=hotfix-route-test&description=Testing+route",
+    );
+
+    await expect(page.getByRole("heading", { name: "Create a New Skill" })).toBeVisible({
+      timeout: 10_000,
+    });
+
+    const promptTextarea = page.locator(
+      "textarea[placeholder*='A skill that helps format SQL queries']",
+    );
+    await expect(promptTextarea).toBeVisible();
+    await expect(promptTextarea).toHaveValue("Testing route");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Scenario 5 — Target Agents hidden under claude-code scope (AC-US4-01)
+// ---------------------------------------------------------------------------
+test.describe("0703 — Target Agents visibility gated on active scope", () => {
+  test("under claude-code active scope, the Target Agents section is NOT rendered", async ({
+    page,
+  }) => {
+    // Seed the localStorage BEFORE the SPA hydrates. We first navigate to the
+    // root (same origin) so localStorage is scoped correctly, then set the
+    // preference, then navigate to /#/create.
+    await page.goto("/");
+    await page.evaluate(() => {
+      try {
+        window.localStorage.setItem(
+          "vskill.studio.prefs",
+          JSON.stringify({ activeAgent: "claude-code" }),
+        );
+      } catch {
+        // ignore
+      }
+    });
+
+    await page.goto("/#/create?mode=standalone&skillName=hotfix-scope-test");
+    await expect(page.getByRole("heading", { name: "Create a New Skill" })).toBeVisible({
+      timeout: 10_000,
+    });
+
+    // The Target Agents section header must NOT appear.
+    const pageText = (await page.locator("body").textContent()) ?? "";
+    expect(pageText).not.toMatch(/Target Agents/);
+  });
+});

--- a/e2e/fixtures/skills/hotfix-dup-test/SKILL.md
+++ b/e2e/fixtures/skills/hotfix-dup-test/SKILL.md
@@ -1,0 +1,10 @@
+---
+description: "Pre-seeded skill used by the 0703 E2E duplicate-name regression guard. Do not remove."
+allowed-tools: Read
+model: sonnet
+---
+
+# /hotfix-dup-test
+
+Fixture skill used only to prove the CreateSkillModal pre-flight duplicate check
+rejects colliding names before navigating to /#/create.

--- a/src/eval-server/__tests__/authoring-routes.test.ts
+++ b/src/eval-server/__tests__/authoring-routes.test.ts
@@ -7,7 +7,7 @@ import { mkdtempSync, rmSync, existsSync, readFileSync, writeFileSync, mkdirSync
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { EventEmitter } from "node:events";
-import { makeCreateSkillHandler } from "../authoring-routes.js";
+import { makeCreateSkillHandler, makeSkillExistsHandler } from "../authoring-routes.js";
 
 class FakeReq extends EventEmitter {
   headers: Record<string, string> = {};
@@ -189,5 +189,93 @@ describe("POST /api/authoring/create-skill — validation", () => {
     await h(req as any, res as any);
     expect(res.statusCode).toBe(400);
     expect((res.json as { code: string }).code).toBe("invalid-plugin-name");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 0703 hotfix — GET /api/authoring/skill-exists (pre-flight duplicate check
+// for the "Generate with AI" branch of CreateSkillModal)
+// ---------------------------------------------------------------------------
+
+class FakeGetReq {
+  headers: Record<string, string> = {};
+  method = "GET";
+  url: string;
+  constructor(path: string) {
+    this.url = path;
+  }
+}
+
+describe("0703 — GET /api/authoring/skill-exists", () => {
+  it("returns exists:false for a fresh standalone skill name", async () => {
+    const h = makeSkillExistsHandler(root);
+    const req = new FakeGetReq("/api/authoring/skill-exists?mode=standalone&skillName=anton-greet");
+    const res = new FakeRes();
+    await h(req as any, res as any);
+    expect(res.statusCode).toBe(200);
+    const body = res.json as { exists: boolean; path: string };
+    expect(body.exists).toBe(false);
+    expect(body.path).toContain("skills/anton-greet");
+  });
+
+  it("returns exists:true when the standalone skill dir is already on disk", async () => {
+    mkdirSync(join(root, "skills", "anton-greet"), { recursive: true });
+    writeFileSync(join(root, "skills", "anton-greet", "SKILL.md"), "# existing");
+
+    const h = makeSkillExistsHandler(root);
+    const req = new FakeGetReq("/api/authoring/skill-exists?mode=standalone&skillName=anton-greet");
+    const res = new FakeRes();
+    await h(req as any, res as any);
+    expect(res.statusCode).toBe(200);
+    const body = res.json as { exists: boolean; path: string };
+    expect(body.exists).toBe(true);
+    expect(body.path).toContain("skills/anton-greet");
+  });
+
+  it("returns exists:true for existing-plugin mode when the skill dir is there", async () => {
+    mkdirSync(join(root, "my-plugin", ".claude-plugin"), { recursive: true });
+    writeFileSync(
+      join(root, "my-plugin", ".claude-plugin", "plugin.json"),
+      JSON.stringify({ name: "my-plugin", version: "0.0.1" }),
+    );
+    mkdirSync(join(root, "my-plugin", "skills", "greeter"), { recursive: true });
+
+    const h = makeSkillExistsHandler(root);
+    const req = new FakeGetReq(
+      "/api/authoring/skill-exists?mode=existing-plugin&pluginName=my-plugin&skillName=greeter",
+    );
+    const res = new FakeRes();
+    await h(req as any, res as any);
+    expect(res.statusCode).toBe(200);
+    expect((res.json as { exists: boolean }).exists).toBe(true);
+  });
+
+  it("returns 404 plugin-not-found when existing-plugin mode targets a missing plugin", async () => {
+    const h = makeSkillExistsHandler(root);
+    const req = new FakeGetReq(
+      "/api/authoring/skill-exists?mode=existing-plugin&pluginName=ghost&skillName=foo",
+    );
+    const res = new FakeRes();
+    await h(req as any, res as any);
+    expect(res.statusCode).toBe(404);
+    expect((res.json as { code: string }).code).toBe("plugin-not-found");
+  });
+
+  it("returns 400 invalid-skill-name for non-kebab inputs", async () => {
+    const h = makeSkillExistsHandler(root);
+    const req = new FakeGetReq("/api/authoring/skill-exists?mode=standalone&skillName=BAD%20NAME");
+    const res = new FakeRes();
+    await h(req as any, res as any);
+    expect(res.statusCode).toBe(400);
+    expect((res.json as { code: string }).code).toBe("invalid-skill-name");
+  });
+
+  it("returns 400 invalid-mode for unknown mode", async () => {
+    const h = makeSkillExistsHandler(root);
+    const req = new FakeGetReq("/api/authoring/skill-exists?mode=bogus&skillName=foo");
+    const res = new FakeRes();
+    await h(req as any, res as any);
+    expect(res.statusCode).toBe(400);
+    expect((res.json as { code: string }).code).toBe("invalid-mode");
   });
 });

--- a/src/eval-server/authoring-routes.ts
+++ b/src/eval-server/authoring-routes.ts
@@ -185,9 +185,59 @@ export function makeCreateSkillHandler(root: string) {
   };
 }
 
+// ---------------------------------------------------------------------------
+// 0703 hotfix — GET /api/authoring/skill-exists
+//
+// Pre-flight probe used by CreateSkillModal before it redirects to the
+// generator. Mirrors the validation + skillDir resolution from the POST
+// handler but NEVER writes; just returns { exists, path }. Returns 400 on
+// invalid input, 404 when existing-plugin mode targets a missing plugin.
+// ---------------------------------------------------------------------------
+export function makeSkillExistsHandler(root: string) {
+  return async function handler(req: IncomingMessage, res: ServerResponse): Promise<void> {
+    const url = new URL(req.url ?? "/", "http://localhost");
+    const mode = url.searchParams.get("mode");
+    const skillName = url.searchParams.get("skillName") ?? undefined;
+    const pluginName = url.searchParams.get("pluginName") ?? undefined;
+
+    if (mode !== "standalone" && mode !== "existing-plugin" && mode !== "new-plugin") {
+      return sendError(res, 400, "invalid-mode", "mode must be 'standalone', 'existing-plugin', or 'new-plugin'");
+    }
+
+    const skillErr = validateKebab(skillName, "skillName");
+    if (skillErr) return sendError(res, 400, "invalid-skill-name", skillErr);
+
+    let skillDir: string;
+    if (mode === "standalone") {
+      skillDir = join(root, "skills", skillName!);
+    } else {
+      const pluginErr = validateKebab(pluginName, "pluginName");
+      if (pluginErr) return sendError(res, 400, "invalid-plugin-name", pluginErr);
+      const pluginDir = join(root, pluginName!);
+      if (mode === "existing-plugin") {
+        const manifestPath = join(pluginDir, ".claude-plugin", "plugin.json");
+        if (!existsSync(manifestPath)) {
+          return sendError(
+            res,
+            404,
+            "plugin-not-found",
+            `Plugin '${pluginName}' not found: ${manifestPath} does not exist`,
+          );
+        }
+      }
+      skillDir = join(pluginDir, "skills", skillName!);
+    }
+
+    sendJson(res, { exists: existsSync(skillDir), path: skillDir }, 200);
+  };
+}
+
 export function registerAuthoringRoutes(router: Router, root: string): void {
   const handler = makeCreateSkillHandler(root);
   router.post("/api/authoring/create-skill", (req, res) => handler(req, res));
+
+  const existsHandler = makeSkillExistsHandler(root);
+  router.get("/api/authoring/skill-exists", (req, res) => existsHandler(req, res));
 
   // Helper endpoint: list authored plugins in the current root so the modal
   // can populate the "existing plugin" dropdown.

--- a/src/eval-ui/src/App.tsx
+++ b/src/eval-ui/src/App.tsx
@@ -42,6 +42,30 @@ import { strings } from "./strings";
 // T-039: CommandPalette is lazy-loaded so it stays out of the initial bundle.
 const CommandPalette = lazy(() => import("./components/CommandPalette"));
 
+// 0703 hotfix: lazy-load CreateSkillPage because it is only mounted when the
+// hash is `/create` (the modal's Generate-with-AI branch). Keeping it out of
+// the initial bundle preserves home-page LCP.
+const CreateSkillPage = lazy(() =>
+  import("./pages/CreateSkillPage").then((m) => ({ default: m.CreateSkillPage })),
+);
+
+function useIsCreateRoute(): boolean {
+  const [onCreate, setOnCreate] = useState<boolean>(() =>
+    typeof window !== "undefined" && window.location.hash.startsWith("#/create"),
+  );
+  useEffect(() => {
+    function onHashChange(): void {
+      setOnCreate(window.location.hash.startsWith("#/create"));
+    }
+    window.addEventListener("hashchange", onHashChange);
+    // Fire once on mount — Vite HMR + some navigation paths (window.location
+    // .assign before listener attach) need the sync read.
+    onHashChange();
+    return () => window.removeEventListener("hashchange", onHashChange);
+  }, []);
+  return onCreate;
+}
+
 export function App() {
   return (
     <ConfigProvider>
@@ -307,6 +331,18 @@ function Shell() {
         }),
     },
   ]);
+
+  const onCreateRoute = useIsCreateRoute();
+
+  if (onCreateRoute) {
+    // 0703 hotfix: full-page takeover for the Generate-with-AI landing. No
+    // sidebar/topRail — this is a focused task flow; cancel returns to "/".
+    return (
+      <Suspense fallback={<div style={{ padding: 40 }}>Loading…</div>}>
+        <CreateSkillPage />
+      </Suspense>
+    );
+  }
 
   return (
     <>

--- a/src/eval-ui/src/components/CreateSkillModal.tsx
+++ b/src/eval-ui/src/components/CreateSkillModal.tsx
@@ -119,7 +119,41 @@ export function CreateSkillModal({
 
   const pathPreview = computePathPreview(projectRoot, mode, pluginName, skillName);
 
-  function routeToGenerator(): void {
+  async function routeToGenerator(): Promise<void> {
+    // 0703 hotfix: pre-flight uniqueness check before we navigate off. The
+    // "Create empty scaffold" path already handles 409 server-side, but the
+    // AI branch previously redirected blindly and users only discovered the
+    // clash after investing a prompt. Fail fast instead.
+    setError(null);
+    setSubmitting(true);
+    try {
+      const probeParams = new URLSearchParams();
+      probeParams.set("mode", mode);
+      probeParams.set("skillName", skillName);
+      if (pluginName) probeParams.set("pluginName", pluginName);
+      const probeRes = await fetch(`/api/authoring/skill-exists?${probeParams.toString()}`);
+      const probeBody = (await probeRes.json()) as {
+        exists?: boolean;
+        path?: string;
+        error?: string;
+      };
+      if (!probeRes.ok) {
+        setError(probeBody.error ?? `Check failed: ${probeRes.status}`);
+        return;
+      }
+      if (probeBody.exists) {
+        setError(
+          `Skill '${skillName}' already exists${probeBody.path ? ` at ${probeBody.path}` : ""}`,
+        );
+        return;
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+      return;
+    } finally {
+      setSubmitting(false);
+    }
+
     // 0698 polish: chain to the existing AI-generation flow at /create with
     // the destination pre-encoded as query params so the page can surface the
     // target path in its UI.
@@ -421,7 +455,7 @@ export function CreateSkillModal({
               </button>
               <button
                 type="button"
-                onClick={routeToGenerator}
+                onClick={() => void routeToGenerator()}
                 disabled={!canSubmit}
                 style={{ ...secondaryButtonStyle, opacity: canSubmit ? 1 : 0.5, cursor: canSubmit ? "pointer" : "not-allowed" }}
                 title="Opens the AI generation flow with this destination pre-selected (choose Claude Code, Anthropic API, OpenRouter, or local models)"

--- a/src/eval-ui/src/components/ModelList.tsx
+++ b/src/eval-ui/src/components/ModelList.tsx
@@ -184,6 +184,7 @@ export function ModelList({ agent, activeModelId, onSelect, onOpenSettings }: Mo
                   model={model}
                   isActive={model.id === activeModelId}
                   onSelect={() => onSelect(model.id)}
+                  resolvedModel={agent.id === "claude-cli" ? agent.resolvedModel ?? null : null}
                 />
               ))}
             </div>
@@ -198,10 +199,22 @@ interface ModelRowProps {
   model: ModelEntry;
   isActive: boolean;
   onSelect: () => void;
+  resolvedModel?: string | null;
 }
 
-function ModelRow({ model, isActive, onSelect }: ModelRowProps) {
+// 0703 hotfix: the resolved ID from ~/.claude/settings.json describes the
+// Claude Code default when no --model flag is passed. vskill always passes
+// --model <alias>, so showing "routing to claude-opus-4-7" on the Sonnet row
+// teaches the wrong mental model. Gate the sub-line on substring match
+// against the model alias (opus | sonnet | haiku).
+function matchesResolvedAlias(modelId: string, resolvedModel: string | null | undefined): boolean {
+  if (!resolvedModel) return false;
+  return resolvedModel.toLowerCase().includes(modelId.toLowerCase());
+}
+
+function ModelRow({ model, isActive, onSelect, resolvedModel }: ModelRowProps) {
   const metadata = formatMetadata(model);
+  const showResolved = matchesResolvedAlias(model.id, resolvedModel);
   return (
     <button
       type="button"
@@ -212,7 +225,11 @@ function ModelRow({ model, isActive, onSelect }: ModelRowProps) {
       title={model.id}
       style={{
         width: "100%",
-        height: ROW_HEIGHT,
+        // 0703 hotfix: minHeight (not fixed height) so 3-line rows grow
+        // without spilling into neighbours. Safe because useVirtualList only
+        // virtualises at >=80 items and rows with resolvedModel are always
+        // on claude-cli (3 models, non-virtualised).
+        minHeight: ROW_HEIGHT,
         padding: "4px 12px",
         display: "flex",
         flexDirection: "column",
@@ -243,6 +260,18 @@ function ModelRow({ model, isActive, onSelect }: ModelRowProps) {
       >
         {metadata}
       </span>
+      {showResolved && (
+        <span
+          data-testid={`model-row-${model.id}-resolved`}
+          style={{
+            fontSize: 11,
+            fontFamily: "'JetBrains Mono Variable', 'JetBrains Mono', monospace",
+            color: "var(--text-muted, var(--text-tertiary))",
+          }}
+        >
+          routing to {resolvedModel}
+        </span>
+      )}
     </button>
   );
 }

--- a/src/eval-ui/src/components/__tests__/CreateSkillModal.0703.test.tsx
+++ b/src/eval-ui/src/components/__tests__/CreateSkillModal.0703.test.tsx
@@ -1,0 +1,193 @@
+// @vitest-environment jsdom
+// ---------------------------------------------------------------------------
+// 0703 — CreateSkillModal pre-flight duplicate check on Generate-with-AI path.
+//
+// The "Generate with AI" button must probe /api/authoring/skill-exists before
+// navigating. If the skill already exists, show an inline error and stay on
+// step 2. Only navigate when exists:false.
+// ---------------------------------------------------------------------------
+
+(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+import React from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { CreateSkillModal } from "../CreateSkillModal";
+
+// Stub out the SWR mutate — modal imports it but we don't care about cache.
+vi.mock("../../hooks/useSWR", () => ({
+  mutate: vi.fn(),
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+interface FetchCall {
+  url: string;
+  init?: RequestInit;
+}
+
+function mountModal(): { container: HTMLElement; unmount: () => void; root: Root } {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  act(() => {
+    root.render(
+      React.createElement(CreateSkillModal, {
+        open: true,
+        onClose: vi.fn(),
+        initialMode: "standalone",
+        isClaudeCode: true,
+        projectRoot: "/tmp/proj",
+      }),
+    );
+  });
+  return {
+    container,
+    root,
+    unmount: () => {
+      act(() => root.unmount());
+      container.remove();
+    },
+  };
+}
+
+async function advanceToDetails(container: HTMLElement): Promise<void> {
+  // Click Continue → (the first "Continue" button is the only one with that label)
+  const continueBtn = Array.from(container.querySelectorAll("button")).find(
+    (b) => b.textContent?.includes("Continue"),
+  );
+  if (!continueBtn) throw new Error("Continue button not found");
+  await act(async () => {
+    continueBtn.click();
+    await Promise.resolve();
+  });
+}
+
+async function typeSkillName(container: HTMLElement, name: string): Promise<void> {
+  // The skill-name input is the only kebab-validated text input on the step-2 screen.
+  const inputs = Array.from(container.querySelectorAll('input[type="text"]'));
+  const skillInput = inputs.find((i) => (i as HTMLInputElement).placeholder === "my-new-skill") as
+    | HTMLInputElement
+    | undefined;
+  if (!skillInput) throw new Error("skill-name input not found");
+  const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, "value")?.set;
+  setter?.call(skillInput, name);
+  skillInput.dispatchEvent(new Event("input", { bubbles: true }));
+  await act(async () => { await Promise.resolve(); });
+}
+
+async function clickGenerateWithAi(container: HTMLElement): Promise<void> {
+  const btn = Array.from(container.querySelectorAll("button")).find(
+    (b) => b.textContent?.includes("Generate with AI"),
+  );
+  if (!btn) throw new Error("Generate with AI button not found");
+  await act(async () => {
+    btn.click();
+    await Promise.resolve();
+  });
+  // let any pending microtasks (fetch resolve) settle
+  await act(async () => { await new Promise((r) => setTimeout(r, 0)); });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+const originalFetch = globalThis.fetch;
+const originalLocation = window.location;
+let fetchCalls: FetchCall[] = [];
+let assignMock: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  fetchCalls = [];
+  assignMock = vi.fn();
+  // jsdom's window.location.assign is not reconfigurable on its own, but the
+  // whole `location` property on `window` is. Swap in a thin proxy.
+  Object.defineProperty(window, "location", {
+    configurable: true,
+    value: {
+      ...originalLocation,
+      assign: assignMock,
+      hash: "",
+      href: originalLocation.href,
+    },
+  });
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  Object.defineProperty(window, "location", {
+    configurable: true,
+    value: originalLocation,
+  });
+});
+
+function stubFetch(response: { ok: boolean; status?: number; body: unknown }): void {
+  globalThis.fetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === "string" ? input : input.toString();
+    fetchCalls.push({ url, init });
+    // /api/authoring/plugins bootstrap call must also succeed
+    if (url.includes("/api/authoring/plugins")) {
+      return {
+        ok: true,
+        json: async () => ({ plugins: [] }),
+      } as Response;
+    }
+    return {
+      ok: response.ok,
+      status: response.status ?? (response.ok ? 200 : 500),
+      json: async () => response.body,
+    } as Response;
+  }) as unknown as typeof fetch;
+}
+
+describe("0703 — CreateSkillModal Generate-with-AI pre-check", () => {
+  it("AC-US2-04: shows error and does NOT navigate when skill already exists", async () => {
+    stubFetch({
+      ok: true,
+      body: { exists: true, path: "/tmp/proj/skills/anton-greet" },
+    });
+
+    const h = mountModal();
+    try {
+      await advanceToDetails(h.container);
+      await typeSkillName(h.container, "anton-greet");
+      await clickGenerateWithAi(h.container);
+
+      expect(assignMock).not.toHaveBeenCalled();
+      expect(h.container.textContent).toMatch(/already exists/i);
+      // Probe must have gone out
+      const probe = fetchCalls.find((c) => c.url.includes("/api/authoring/skill-exists"));
+      expect(probe).toBeDefined();
+      expect(probe!.url).toContain("skillName=anton-greet");
+      expect(probe!.url).toContain("mode=standalone");
+    } finally {
+      h.unmount();
+    }
+  });
+
+  it("AC-US2-05: navigates to /#/create when the skill name is free", async () => {
+    stubFetch({
+      ok: true,
+      body: { exists: false, path: "/tmp/proj/skills/anton-greet" },
+    });
+
+    const h = mountModal();
+    try {
+      await advanceToDetails(h.container);
+      await typeSkillName(h.container, "anton-greet");
+      await clickGenerateWithAi(h.container);
+
+      expect(assignMock).toHaveBeenCalledTimes(1);
+      const navUrl = String(assignMock.mock.calls[0][0]);
+      expect(navUrl).toContain("/#/create");
+      expect(navUrl).toContain("skillName=anton-greet");
+      expect(navUrl).toContain("mode=standalone");
+    } finally {
+      h.unmount();
+    }
+  });
+});

--- a/src/eval-ui/src/components/__tests__/ModelList.0703.test.tsx
+++ b/src/eval-ui/src/components/__tests__/ModelList.0703.test.tsx
@@ -1,0 +1,103 @@
+// @vitest-environment jsdom
+// ---------------------------------------------------------------------------
+// 0703 — ModelRow must:
+//   (a) use minHeight (not fixed height) so 3-line rows don't overflow and
+//       visually overlap the next row (US-003, AC-US3-01).
+//   (b) render "routing to <resolvedModel>" only on the row whose model.id is
+//       referenced by the resolved ID (US-004, AC-US4-01..03).
+// ---------------------------------------------------------------------------
+
+import { describe, it, expect, vi } from "vitest";
+import type { AgentEntry } from "../../hooks/useAgentCatalog";
+
+(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+function claudeCliAgent(resolvedModel: string | null): AgentEntry {
+  return {
+    id: "claude-cli",
+    displayName: "Claude Code",
+    available: true,
+    wrapperFolder: null,
+    wrapperFolderPresent: false,
+    binaryAvailable: true,
+    endpointReachable: null,
+    ctaType: null,
+    resolvedModel,
+    models: [
+      { id: "sonnet", displayName: "Claude Sonnet", billingMode: "subscription" },
+      { id: "opus", displayName: "Claude Opus", billingMode: "subscription" },
+      { id: "haiku", displayName: "Claude Haiku", billingMode: "subscription" },
+    ],
+  } as AgentEntry;
+}
+
+async function renderModelList(agent: AgentEntry, activeModelId: string | null = null): Promise<HTMLElement> {
+  const React = await import("react");
+  const { createRoot } = await import("react-dom/client");
+  const { act } = await import("react");
+  const { ModelList } = await import("../ModelList");
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  act(() => {
+    root.render(
+      React.createElement(ModelList, {
+        agent,
+        activeModelId,
+        onSelect: vi.fn(),
+        onOpenSettings: vi.fn(),
+      }),
+    );
+  });
+  return container;
+}
+
+describe("0703 — ModelRow layout (AC-US3-01)", () => {
+  it("uses minHeight, not fixed height, so rows with resolvedModel can grow", async () => {
+    const container = await renderModelList(
+      claudeCliAgent("claude-opus-4-7[1m]"),
+      "opus",
+    );
+    const rows = Array.from(
+      container.querySelectorAll<HTMLButtonElement>('[role="option"]'),
+    );
+    expect(rows.length).toBe(3);
+    for (const row of rows) {
+      // Fixed height would render the 3rd line outside its parent box.
+      expect(row.style.height).toBe("");
+      expect(row.style.minHeight).toMatch(/44px/);
+    }
+  });
+});
+
+describe("0703 — resolvedModel appears only on matching alias row (AC-US4-01..03)", () => {
+  it("only the 'opus' row shows 'routing to claude-opus-4-7[1m]' when that is the resolved ID", async () => {
+    const container = await renderModelList(
+      claudeCliAgent("claude-opus-4-7[1m]"),
+      "opus",
+    );
+    const resolvedCount = container.querySelectorAll('[data-testid$="-resolved"]').length;
+    expect(resolvedCount).toBe(1);
+
+    const opusRow = container.querySelector('[data-testid="model-row-opus"]');
+    const sonnetRow = container.querySelector('[data-testid="model-row-sonnet"]');
+    const haikuRow = container.querySelector('[data-testid="model-row-haiku"]');
+    expect(opusRow?.textContent).toMatch(/routing to claude-opus-4-7\[1m\]/);
+    expect(sonnetRow?.textContent ?? "").not.toMatch(/routing to/);
+    expect(haikuRow?.textContent ?? "").not.toMatch(/routing to/);
+  });
+
+  it("shows 'routing to' on the 'sonnet' row when resolvedModel contains sonnet", async () => {
+    const container = await renderModelList(claudeCliAgent("claude-sonnet-4-6"), "sonnet");
+    const sonnetRow = container.querySelector('[data-testid="model-row-sonnet"]');
+    expect(sonnetRow?.textContent).toMatch(/routing to claude-sonnet-4-6/);
+
+    const opusRow = container.querySelector('[data-testid="model-row-opus"]');
+    expect(opusRow?.textContent ?? "").not.toMatch(/routing to/);
+  });
+
+  it("renders no routing sub-line at all when resolvedModel is null", async () => {
+    const container = await renderModelList(claudeCliAgent(null), "opus");
+    expect(container.querySelectorAll('[data-testid$="-resolved"]').length).toBe(0);
+  });
+});

--- a/src/eval-ui/src/main.tsx
+++ b/src/eval-ui/src/main.tsx
@@ -1,5 +1,6 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
+import { HashRouter } from "react-router-dom";
 import { App } from "./App";
 import { ThemeProvider } from "./theme/ThemeProvider";
 import { runScopeRenameMigration } from "./lib/scope-migration";
@@ -47,10 +48,16 @@ if (typeof window !== "undefined" && window.localStorage) {
   }
 }
 
+// 0703 hotfix: wrap App in HashRouter so `CreateSkillPage` (mounted via a
+// hash-based conditional in App.tsx) can use `useNavigate`/`Link` without
+// blowing up on missing router context. The actual routing tree is a single
+// `/create` branch — StudioLayout owns everything else.
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
-    <ThemeProvider>
-      <App />
-    </ThemeProvider>
+    <HashRouter>
+      <ThemeProvider>
+        <App />
+      </ThemeProvider>
+    </HashRouter>
   </StrictMode>,
 );

--- a/src/eval-ui/src/pages/CreateSkillPage.tsx
+++ b/src/eval-ui/src/pages/CreateSkillPage.tsx
@@ -11,6 +11,7 @@ import type { InstalledAgentEntry } from "../components/AgentSelector";
 import {
   readStudioPreferences,
   writeStudioPreference,
+  getStudioPreference,
 } from "../hooks/useStudioPreferences";
 
 // ---------------------------------------------------------------------------
@@ -116,6 +117,14 @@ export function CreateSkillPage() {
   // Installed agents list (loaded from API)
   const [installedAgents, setInstalledAgents] = useState<InstalledAgentEntry[]>([]);
 
+  // 0703 hotfix: active scope agent drives whether the Target Agents section
+  // is shown. A Claude-Code-scoped skill lives in .claude/skills and targets
+  // Claude Code by default — surfacing Cursor / Codex CLI / Copilot rows is
+  // noise. When the user picks a non-Claude scope (e.g. Cursor), the section
+  // reappears so they can still opt into cross-platform targets.
+  const activeAgentId = getStudioPreference<string | null>("activeAgent", null);
+  const showTargetAgents = activeAgentId !== "claude-code";
+
   // Load installed agents from API
   useEffect(() => {
     fetch("/api/agents/installed")
@@ -218,12 +227,18 @@ export function CreateSkillPage() {
   });
 
   // 0698 polish: apply modal-chain prefill once on mount.
+  // 0703 hotfix: also seed aiPrompt from ?description so the Generate button
+  // is enabled on arrival (otherwise the user lands on an empty textarea and
+  // thinks the flow is dead).
   useEffect(() => {
     if (prefill.skillName && !sk.name) {
       sk.setName(toKebab(prefill.skillName));
     }
     if (prefill.description && !sk.description) {
       sk.setDescription(prefill.description);
+    }
+    if (prefill.description && !sk.aiPrompt) {
+      sk.setAiPrompt(prefill.description);
     }
     if (prefill.pluginName && !sk.plugin) {
       sk.setPlugin(toKebab(prefill.pluginName));
@@ -488,8 +503,10 @@ export function CreateSkillPage() {
               </div>
             </div>
 
-            {/* Target Agents (optional) */}
-            {installedAgents.length > 0 && (
+            {/* Target Agents (optional) — hidden when Claude Code is the
+                active scope (0703: Claude-Code-scoped skills don't need
+                cross-platform target-agents). */}
+            {showTargetAgents && installedAgents.length > 0 && (
               <div className="glass-card p-5">
                 <h3 className="text-[13px] font-semibold mb-3" style={{ color: "var(--text-primary)" }}>
                   Target Agents

--- a/src/eval-ui/src/pages/__tests__/CreateSkillPage.prefill.test.tsx
+++ b/src/eval-ui/src/pages/__tests__/CreateSkillPage.prefill.test.tsx
@@ -1,0 +1,177 @@
+// @vitest-environment jsdom
+// ---------------------------------------------------------------------------
+// 0703 — Hotfix: Generate-with-AI modal passes `description` via URL. The
+// landing page must copy it into `aiPrompt` so the Generate button is enabled
+// on arrival (US-001, AC-US1-01..03).
+// ---------------------------------------------------------------------------
+
+(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+import React from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+
+import type { ConfigResponse, ProviderInfo } from "../../api";
+
+// ---------------------------------------------------------------------------
+// Capture setter calls across renders — the stub below reuses these refs.
+// ---------------------------------------------------------------------------
+const setAiPromptMock = vi.fn();
+const setNameMock = vi.fn();
+const setDescriptionMock = vi.fn();
+const setPluginMock = vi.fn();
+
+vi.mock("../../ConfigContext", () => ({
+  useConfig: () => ({
+    config: {
+      provider: null,
+      model: "sonnet",
+      providers: [
+        {
+          id: "claude-cli",
+          label: "Use current Claude Code session",
+          available: true,
+          models: [{ id: "sonnet", label: "Sonnet" }, { id: "opus", label: "Opus" }],
+        },
+      ] as ProviderInfo[],
+      projectName: "vskill",
+      root: "/tmp/vskill",
+    } satisfies ConfigResponse,
+    loading: false,
+    updateConfig: vi.fn(),
+    refreshConfig: vi.fn(),
+  }),
+}));
+
+vi.mock("../../hooks/useCreateSkill", () => ({
+  toKebab: (s: string) => s.toLowerCase().replace(/[^a-z0-9-]+/g, "-"),
+  useCreateSkill: () => ({
+    mode: "ai",
+    setMode: vi.fn(),
+    layoutLoading: false,
+    layout: {
+      detectedLayouts: [],
+      suggestedLayout: 1,
+      existingSkills: [],
+      root: "/tmp",
+    },
+    creatableLayouts: [{ layout: 1, label: "plugin", existingPlugins: [] }],
+    selectedLayout: 1,
+    setSelectedLayout: vi.fn(),
+    plugin: "",
+    setPlugin: setPluginMock,
+    newPlugin: "",
+    setNewPlugin: vi.fn(),
+    availablePlugins: [],
+    pathPreview: "plugins/x/skills/y",
+    showPluginRecommendation: false,
+    setShowPluginRecommendation: vi.fn(),
+    pluginLayoutInfo: null,
+    applyPluginRecommendation: vi.fn(),
+    name: "",
+    setName: setNameMock,
+    description: "",
+    setDescription: setDescriptionMock,
+    model: "",
+    setModel: vi.fn(),
+    allowedTools: "",
+    setAllowedTools: vi.fn(),
+    body: "",
+    setBody: vi.fn(),
+    bodyViewMode: "write",
+    setBodyViewMode: vi.fn(),
+    targetAgents: [],
+    setTargetAgents: vi.fn(),
+    aiPrompt: "",
+    setAiPrompt: setAiPromptMock,
+    promptRef: { current: null },
+    generating: false,
+    aiProgress: [],
+    aiError: null,
+    aiClassifiedError: null,
+    clearAiError: vi.fn(),
+    handleGenerate: vi.fn(),
+    handleCancelGenerate: vi.fn(),
+    handleCreate: vi.fn(),
+    creating: false,
+    error: null,
+    draftSaved: false,
+  }),
+}));
+
+vi.mock("react-router-dom", async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...actual,
+    useNavigate: () => vi.fn(),
+    Link: ({ children, to: _to, ...rest }: { children: React.ReactNode; to: string }) =>
+      React.createElement("a", rest, children),
+  };
+});
+
+const originalFetch = globalThis.fetch;
+beforeEach(() => {
+  globalThis.fetch = vi.fn(async () => ({
+    ok: true,
+    json: async () => ({ agents: [] }),
+  })) as unknown as typeof fetch;
+  localStorage.clear();
+  setAiPromptMock.mockClear();
+  setNameMock.mockClear();
+  setDescriptionMock.mockClear();
+  setPluginMock.mockClear();
+});
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  // Reset hash so tests don't leak into each other.
+  window.location.hash = "";
+});
+
+async function mountWithHash(hash: string): Promise<{ unmount: () => void }> {
+  window.location.hash = hash;
+  const { CreateSkillPage } = await import("../CreateSkillPage");
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root: Root = createRoot(container);
+  await act(async () => {
+    root.render(React.createElement(CreateSkillPage));
+  });
+  // flush mount effects
+  await act(async () => { await Promise.resolve(); });
+  return {
+    unmount: () => {
+      act(() => root.unmount());
+      container.remove();
+    },
+  };
+}
+
+describe("0703 — CreateSkillPage URL prefill populates aiPrompt", () => {
+  it("AC-US1-01: copies ?description=… into aiPrompt so Generate is enabled", async () => {
+    const h = await mountWithHash("#/create?mode=standalone&skillName=anton-greet&description=Does+X");
+    try {
+      expect(setAiPromptMock).toHaveBeenCalledWith("Does X");
+    } finally {
+      h.unmount();
+    }
+  });
+
+  it("AC-US1-02: also populates sk.description for the SKILL.md preview", async () => {
+    const h = await mountWithHash("#/create?mode=standalone&skillName=anton-greet&description=Does+X");
+    try {
+      expect(setDescriptionMock).toHaveBeenCalledWith("Does X");
+    } finally {
+      h.unmount();
+    }
+  });
+
+  it("AC-US1-03: leaves aiPrompt alone when no ?description param is present", async () => {
+    const h = await mountWithHash("#/create?mode=standalone&skillName=anton-greet");
+    try {
+      expect(setAiPromptMock).not.toHaveBeenCalled();
+    } finally {
+      h.unmount();
+    }
+  });
+});

--- a/src/eval-ui/src/pages/__tests__/CreateSkillPage.targetAgents.test.tsx
+++ b/src/eval-ui/src/pages/__tests__/CreateSkillPage.targetAgents.test.tsx
@@ -1,0 +1,203 @@
+// @vitest-environment jsdom
+// ---------------------------------------------------------------------------
+// 0703 — Hotfix: when the active scope agent is Claude Code, the Target
+// Agents picker must not offer cross-platform options (Cursor, Codex CLI,
+// Copilot, Amp, etc.). A Claude-Code-scoped skill lives in .claude/skills
+// and doesn't need a `target-agents:` header.
+// ---------------------------------------------------------------------------
+
+(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+import React from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+
+import type { ConfigResponse, ProviderInfo } from "../../api";
+
+vi.mock("../../ConfigContext", () => ({
+  useConfig: () => ({
+    config: {
+      provider: null,
+      model: "sonnet",
+      providers: [
+        {
+          id: "claude-cli",
+          label: "Use current Claude Code session",
+          available: true,
+          models: [{ id: "sonnet", label: "Sonnet" }],
+        },
+      ] as ProviderInfo[],
+      projectName: "vskill",
+      root: "/tmp/vskill",
+    } satisfies ConfigResponse,
+    loading: false,
+    updateConfig: vi.fn(),
+    refreshConfig: vi.fn(),
+  }),
+}));
+
+vi.mock("../../hooks/useCreateSkill", () => ({
+  toKebab: (s: string) => s.toLowerCase().replace(/[^a-z0-9-]+/g, "-"),
+  useCreateSkill: () => ({
+    mode: "ai",
+    setMode: vi.fn(),
+    layoutLoading: false,
+    layout: { detectedLayouts: [], suggestedLayout: 1, existingSkills: [], root: "/tmp" },
+    creatableLayouts: [{ layout: 1, label: "plugin", existingPlugins: [] }],
+    selectedLayout: 1,
+    setSelectedLayout: vi.fn(),
+    plugin: "",
+    setPlugin: vi.fn(),
+    newPlugin: "",
+    setNewPlugin: vi.fn(),
+    availablePlugins: [],
+    pathPreview: "plugins/x/skills/y",
+    showPluginRecommendation: false,
+    setShowPluginRecommendation: vi.fn(),
+    pluginLayoutInfo: null,
+    applyPluginRecommendation: vi.fn(),
+    name: "",
+    setName: vi.fn(),
+    description: "",
+    setDescription: vi.fn(),
+    model: "",
+    setModel: vi.fn(),
+    allowedTools: "",
+    setAllowedTools: vi.fn(),
+    body: "",
+    setBody: vi.fn(),
+    bodyViewMode: "write",
+    setBodyViewMode: vi.fn(),
+    targetAgents: [],
+    setTargetAgents: vi.fn(),
+    aiPrompt: "",
+    setAiPrompt: vi.fn(),
+    promptRef: { current: null },
+    generating: false,
+    aiProgress: [],
+    aiError: null,
+    aiClassifiedError: null,
+    clearAiError: vi.fn(),
+    handleGenerate: vi.fn(),
+    handleCancelGenerate: vi.fn(),
+    handleCreate: vi.fn(),
+    creating: false,
+    error: null,
+    draftSaved: false,
+  }),
+}));
+
+vi.mock("react-router-dom", async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...actual,
+    useNavigate: () => vi.fn(),
+    Link: ({ children, to: _to, ...rest }: { children: React.ReactNode; to: string }) =>
+      React.createElement("a", rest, children),
+  };
+});
+
+const INSTALLED_AGENTS = [
+  {
+    id: "claude-code",
+    displayName: "Claude Code",
+    featureSupport: { slashCommands: true, hooks: true, mcp: true, customSystemPrompt: true },
+    isUniversal: false,
+    installed: true,
+  },
+  {
+    id: "cursor",
+    displayName: "Cursor",
+    featureSupport: { slashCommands: true, hooks: false, mcp: true, customSystemPrompt: true },
+    isUniversal: true,
+    installed: true,
+  },
+  {
+    id: "codex-cli",
+    displayName: "Codex CLI",
+    featureSupport: { slashCommands: true, hooks: false, mcp: true, customSystemPrompt: true },
+    isUniversal: true,
+    installed: true,
+  },
+];
+
+const originalFetch = globalThis.fetch;
+beforeEach(() => {
+  globalThis.fetch = vi.fn(async () => ({
+    ok: true,
+    json: async () => ({ agents: INSTALLED_AGENTS }),
+  })) as unknown as typeof fetch;
+  localStorage.clear();
+  window.location.hash = "";
+});
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  window.location.hash = "";
+});
+
+async function mountPage(): Promise<{ container: HTMLElement; unmount: () => void }> {
+  const { CreateSkillPage } = await import("../CreateSkillPage");
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root: Root = createRoot(container);
+  await act(async () => {
+    root.render(React.createElement(CreateSkillPage));
+  });
+  // flush mount effects + API fetch resolution
+  await act(async () => { await Promise.resolve(); });
+  await act(async () => { await new Promise((r) => setTimeout(r, 0)); });
+  return {
+    container,
+    unmount: () => {
+      act(() => root.unmount());
+      container.remove();
+    },
+  };
+}
+
+describe("0703 — Target Agents scoping to active scope agent", () => {
+  it("AC-US5-01: hides Cursor / Codex CLI / Copilot rows when activeAgent is claude-code", async () => {
+    localStorage.setItem("vskill.studio.prefs", JSON.stringify({ activeAgent: "claude-code" }));
+    const h = await mountPage();
+    try {
+      const text = h.container.textContent ?? "";
+      // Debug aid: if this fires the mount isn't even reaching the section.
+      expect(text).toMatch(/Describe Your Skill/);
+      // Sanity: Target Agents header SHOULD appear only if we intend to render
+      // it. For Claude Code scope we expect the header to be absent (section
+      // suppressed entirely).
+      expect(text).not.toMatch(/Target Agents/);
+      expect(text).not.toMatch(/\bCursor\b/);
+      expect(text).not.toMatch(/\bCodex CLI\b/);
+    } finally {
+      h.unmount();
+    }
+  });
+
+  it("AC-US5-02: shows all universal agents when activeAgent is NOT claude-code", async () => {
+    localStorage.setItem("vskill.studio.prefs", JSON.stringify({ activeAgent: "cursor" }));
+    const h = await mountPage();
+    try {
+      const text = h.container.textContent ?? "";
+      expect(text).toMatch(/Cursor/);
+      expect(text).toMatch(/Codex CLI/);
+    } finally {
+      h.unmount();
+    }
+  });
+
+  it("sanity: installed agents actually render without activeAgent preference", async () => {
+    // No preference set → default activeAgent is null → section should show all agents.
+    const h = await mountPage();
+    try {
+      const text = h.container.textContent ?? "";
+      // If this assertion fails, the test harness isn't actually rendering the
+      // Target Agents section (and the other two tests are vacuously passing).
+      expect(text).toMatch(/Target Agents/);
+      expect(text).toMatch(/Cursor/);
+    } finally {
+      h.unmount();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Six compounding bugs in the Skill Studio "+ New Skill → Generate with AI" flow. All fixed with TDD discipline (RED → GREEN) and verified end-to-end in Chromium.

### Bugs fixed

1. **Prompt prefill** — `CreateSkillModal` passes `?description=X` via URL, but the landing page only copied it into `sk.description`, not `sk.aiPrompt`. Generate button stayed disabled → user saw "nothing happens". [CreateSkillPage.tsx]
2. **No duplicate-name check** — Generate-with-AI branch skipped the `POST /api/authoring/create-skill` collision check. Added `GET /api/authoring/skill-exists` probe in `CreateSkillModal.routeToGenerator()`. [authoring-routes.ts + CreateSkillModal.tsx]
3. **⌘K picker overlap** — 0701 added a third line to `ModelRow` but kept `height: 44px`. Third line visually overlapped the next row. `height` → `minHeight`. [ModelList.tsx]
4. **Misleading "routing to"** — resolved model ID shown on every Claude Code row. Now scoped to the row whose alias (opus/sonnet/haiku) matches the resolved ID. [ModelList.tsx]
5. **Dead `/#/create` route** — `CreateSkillPage` was orphaned since commit 2796fd1 removed the router. Wrapped `App` in `HashRouter`; added `useIsCreateRoute()` takeover. **This is the actual root cause of "nothing happens".** [main.tsx + App.tsx]
6. **Target Agents noise** — Cursor/Codex CLI/Amp/Cline rows surfaced even when Claude Code is the active scope. Section now hidden when `activeAgent === "claude-code"`. [CreateSkillPage.tsx]

### Model dispatch — not a bug

Verified at [llm.ts:325-338](src/eval/llm.ts): `claude-cli` spawns `claude -p --model <alias>`, so the user's model choice IS used. Fix #4 corrects the misleading UI that made it look otherwise.

## Test plan

- [x] 18 new unit tests (vitest + jsdom) — all green
  - `CreateSkillPage.prefill.test.tsx` (3 cases)
  - `CreateSkillPage.targetAgents.test.tsx` (3 cases)
  - `CreateSkillModal.0703.test.tsx` (2 cases)
  - `ModelList.0703.test.tsx` (4 cases)
  - `authoring-routes.test.ts` (+6 cases for `skill-exists`)
- [x] 5 Playwright E2E scenarios (`e2e/0703-create-flow-hotfix.spec.ts`) — 5/5 passed in Chromium
- [x] 0701 regression suite (5 cases) still green
- [x] `npx tsc --noEmit` clean
- [x] Pre-existing failures on main (TopRail breadcrumb + picker-tooltip) unchanged — verified by stashing

## SpecWeave increment

`0703-studio-create-flow-hotfix` in the umbrella repo — spec.md / plan.md / tasks.md written retrospectively by PM + Architect + Planner sub-agents. Synced to ADO as FS-703 with 6 user stories.