### PR TITLE
0703 follow-up: studio chrome, blue CTAs, placement pinning, plugin.json per docs

### DIFF
--- a/src/eval-server/__tests__/authoring-routes.test.ts
+++ b/src/eval-server/__tests__/authoring-routes.test.ts
@@ -114,10 +114,16 @@ describe("POST /api/authoring/create-skill — new-plugin", () => {
 
     const manifest = JSON.parse(readFileSync(body.manifestPath, "utf8")) as {
       name: string;
-      version: string;
+      version?: string;
+      author?: { name: string };
     };
     expect(manifest.name).toBe("my-first-plugin");
-    expect(manifest.version).toBe("0.1.0");
+    // 0703 follow-up: version is intentionally omitted so Claude Code falls
+    // back to git SHA (per plugins-reference docs — avoids "forgot to bump"
+    // footgun). Confirm we do NOT emit a hardcoded version.
+    expect(manifest.version).toBeUndefined();
+    // 0703 follow-up: author is an object-shaped stub per schema.
+    expect(manifest.author).toEqual({ name: "" });
   });
 
   it("rejects if the plugin directory already exists (409)", async () => {

--- a/src/eval-server/authoring-routes.ts
+++ b/src/eval-server/authoring-routes.ts
@@ -75,12 +75,18 @@ function skillMdScaffold(skillName: string, description: string): string {
 }
 
 function pluginJsonScaffold(pluginName: string, description: string): string {
+  // 0703 follow-up: align with https://code.claude.com/docs/en/plugins-reference
+  // `name` is the only required field. `version` is intentionally omitted so
+  // Claude Code falls back to the git SHA — docs explicitly warn that a fixed
+  // `version: "0.1.0"` is a footgun (users stop receiving updates unless the
+  // author remembers to bump it). `author` is an object per the schema, not a
+  // string; we stub the name so the user only has to fill it in.
   return (
     JSON.stringify(
       {
         name: pluginName,
-        version: "0.1.0",
         description,
+        author: { name: "" },
       },
       null,
       2,

--- a/src/eval-ui/src/App.tsx
+++ b/src/eval-ui/src/App.tsx
@@ -334,15 +334,23 @@ function Shell() {
 
   const onCreateRoute = useIsCreateRoute();
 
-  if (onCreateRoute) {
-    // 0703 hotfix: full-page takeover for the Generate-with-AI landing. No
-    // sidebar/topRail — this is a focused task flow; cancel returns to "/".
-    return (
-      <Suspense fallback={<div style={{ padding: 40 }}>Loading…</div>}>
-        <CreateSkillPage />
-      </Suspense>
-    );
-  }
+  // 0703 follow-up: keep StudioLayout chrome (TopRail, sidebar, ⌘K, brand)
+  // visible when CreateSkillPage is active, so users don't feel teleported to
+  // a standalone page and still have escape hatches. The page renders in the
+  // main slot instead of replacing the whole tree.
+  const mainContent = onCreateRoute ? (
+    <Suspense fallback={<div style={{ padding: 40 }}>Loading…</div>}>
+      <CreateSkillPage />
+    </Suspense>
+  ) : (
+    <RightPanel
+      selectedSkillInfo={selectedInfo}
+      activeDetailTab={activeDetailTab}
+      onDetailTabChange={setActiveDetailTab}
+      allSkills={state.skills}
+      onSelectSkill={onSelect}
+    />
+  );
 
   return (
     <>
@@ -407,15 +415,7 @@ function Shell() {
         resizeHandle={
           <ResizeHandle initialWidth={sidebarWidth ?? DEFAULT_SIDEBAR_WIDTH} onChange={setSidebarWidth} />
         }
-        main={
-          <RightPanel
-            selectedSkillInfo={selectedInfo}
-            activeDetailTab={activeDetailTab}
-            onDetailTabChange={setActiveDetailTab}
-            allSkills={state.skills}
-            onSelectSkill={onSelect}
-          />
-        }
+        main={mainContent}
         statusBar={
           <StatusBar
             projectPath={config?.root ?? null}

--- a/src/eval-ui/src/hooks/__tests__/useCreateSkill.pinning.test.ts
+++ b/src/eval-ui/src/hooks/__tests__/useCreateSkill.pinning.test.ts
@@ -1,0 +1,92 @@
+// ---------------------------------------------------------------------------
+// 0703 follow-up: decideGenerationPinning — user-pinned placement must win
+// over AI `data.name` / `suggestedPlugin`. Without this, selecting
+// `mode=new-plugin&pluginName=test-plugin&skillName=test-plugin-skill` in the
+// modal ends up landing the skill as `task-skill-announcer` inside the first
+// existing plugin the AI picks (e.g. `frontend`).
+// ---------------------------------------------------------------------------
+
+import { describe, it, expect } from "vitest";
+import { decideGenerationPinning } from "../useCreateSkill";
+
+describe("decideGenerationPinning", () => {
+  it("user-provided name overrides AI name", () => {
+    const d = decideGenerationPinning({
+      userName: "test-plugin-skill",
+      userPlugin: "",
+      userNewPlugin: "",
+      aiName: "task-skill-announcer",
+      aiSuggestedPlugin: null,
+    });
+    expect(d.applyName).toBeNull();
+  });
+
+  it("when user has no name, AI name is applied", () => {
+    const d = decideGenerationPinning({
+      userName: "",
+      userPlugin: "",
+      userNewPlugin: "",
+      aiName: "task-skill-announcer",
+      aiSuggestedPlugin: null,
+    });
+    expect(d.applyName).toBe("task-skill-announcer");
+  });
+
+  it("user-selected plugin blocks suggestedPlugin", () => {
+    const d = decideGenerationPinning({
+      userName: "",
+      userPlugin: "my-plugin",
+      userNewPlugin: "",
+      aiName: "foo",
+      aiSuggestedPlugin: { plugin: "frontend" },
+    });
+    expect(d.applySuggestedPlugin).toBe(false);
+    expect(d.suggestedPluginValue).toBeNull();
+  });
+
+  it("user-typed newPlugin (new-plugin mode) blocks suggestedPlugin", () => {
+    const d = decideGenerationPinning({
+      userName: "",
+      userPlugin: "__new__",
+      userNewPlugin: "test-plugin",
+      aiName: "foo",
+      aiSuggestedPlugin: { plugin: "frontend" },
+    });
+    expect(d.applySuggestedPlugin).toBe(false);
+  });
+
+  it("when user has no plugin, AI suggestedPlugin is applied", () => {
+    const d = decideGenerationPinning({
+      userName: "",
+      userPlugin: "",
+      userNewPlugin: "",
+      aiName: "foo",
+      aiSuggestedPlugin: { plugin: "frontend", layout: 1 },
+    });
+    expect(d.applySuggestedPlugin).toBe(true);
+    expect(d.suggestedPluginValue).toEqual({ plugin: "frontend", layout: 1 });
+  });
+
+  it("whitespace-only user fields are treated as unset", () => {
+    const d = decideGenerationPinning({
+      userName: "   ",
+      userPlugin: "\t",
+      userNewPlugin: "",
+      aiName: "foo",
+      aiSuggestedPlugin: { plugin: "frontend" },
+    });
+    expect(d.applyName).toBe("foo");
+    expect(d.applySuggestedPlugin).toBe(true);
+  });
+
+  it("null suggestedPlugin never applies (even when user has no plugin)", () => {
+    const d = decideGenerationPinning({
+      userName: "",
+      userPlugin: "",
+      userNewPlugin: "",
+      aiName: "foo",
+      aiSuggestedPlugin: null,
+    });
+    expect(d.applySuggestedPlugin).toBe(false);
+  });
+});

--- a/src/eval-ui/src/hooks/useCreateSkill.ts
+++ b/src/eval-ui/src/hooks/useCreateSkill.ts
@@ -32,6 +32,47 @@ export function buildGenerateRequestBody(input: GenerateRequestInput): Record<st
   return body;
 }
 
+// ---------------------------------------------------------------------------
+// 0703 follow-up: placement-pinning decision helper.
+//
+// The AI backend returns `data.name` and `data.suggestedPlugin`. When the
+// user has already specified a skill name / plugin destination (via URL
+// prefill from the CreateSkillModal, or by typing in the form before
+// clicking Generate), those explicit choices MUST win over the AI's
+// suggestion. Otherwise skill `test-plugin-skill` + plugin `test-plugin`
+// silently becomes `task-skill-announcer` in some pre-existing plugin
+// like `frontend` — exactly the "it landed in the wrong place" bug users
+// reported.
+//
+// Pure function so it is trivial to unit-test without driving the SSE
+// stream end-to-end.
+// ---------------------------------------------------------------------------
+export interface PinningInput {
+  userName: string;
+  userPlugin: string;     // selected plugin id ("" | "__new__" | <name>)
+  userNewPlugin: string;  // typed new plugin name
+  aiName: string | undefined;
+  aiSuggestedPlugin: { plugin: string; layout?: 1 | 2 } | null | undefined;
+}
+
+export interface PinningDecision {
+  applyName: string | null;                          // null → keep user's
+  applySuggestedPlugin: boolean;                     // false → keep user's
+  suggestedPluginValue: { plugin: string; layout?: 1 | 2 } | null;
+}
+
+export function decideGenerationPinning(input: PinningInput): PinningDecision {
+  const userPinnedName = input.userName.trim().length > 0;
+  const userPinnedPlugin =
+    input.userPlugin.trim().length > 0 || input.userNewPlugin.trim().length > 0;
+
+  return {
+    applyName: userPinnedName ? null : input.aiName ?? null,
+    applySuggestedPlugin: !userPinnedPlugin && !!input.aiSuggestedPlugin?.plugin,
+    suggestedPluginValue: userPinnedPlugin ? null : (input.aiSuggestedPlugin ?? null),
+  };
+}
+
 export function toKebab(s: string, trim = true): string {
   let r = s.toLowerCase().replace(/[^a-z0-9]+/g, "-");
   if (trim) r = r.replace(/^-+|-+$/g, "");
@@ -192,6 +233,18 @@ export function useCreateSkill({ onCreated, resolveAiConfigOverride }: UseCreate
   // Plugin recommendation
   const [showPluginRecommendation, setShowPluginRecommendation] = useState(false);
 
+  // 0703 follow-up: track user-pinned placement (name / plugin / newPlugin)
+  // via refs so handleGenerate can read the CURRENT values without stale
+  // closure. When the user arrives with explicit URL params (or has typed a
+  // name / picked a plugin before clicking Generate), the AI must not
+  // silently overwrite their choice.
+  const nameRef = useRef(name);
+  const pluginRef = useRef(plugin);
+  const newPluginRef = useRef(newPlugin);
+  useEffect(() => { nameRef.current = name; }, [name]);
+  useEffect(() => { pluginRef.current = plugin; }, [plugin]);
+  useEffect(() => { newPluginRef.current = newPlugin; }, [newPlugin]);
+
   // ---------------------------------------------------------------------------
   // Effects
   // ---------------------------------------------------------------------------
@@ -332,7 +385,21 @@ export function useCreateSkill({ onCreated, resolveAiConfigOverride }: UseCreate
                   reasoning: data.reasoning || "",
                 };
 
-                setName(data.name);
+                // 0703 follow-up: respect user-pinned placement via the
+                // pure `decideGenerationPinning` helper (see tests for the
+                // full decision matrix). If the user arrived with a skill
+                // name / plugin in the URL, those values win over the AI's.
+                const pinning = decideGenerationPinning({
+                  userName: nameRef.current,
+                  userPlugin: pluginRef.current,
+                  userNewPlugin: newPluginRef.current,
+                  aiName: data.name,
+                  aiSuggestedPlugin: data.suggestedPlugin && data.suggestedPlugin.plugin
+                    ? { plugin: data.suggestedPlugin.plugin, layout: data.suggestedPlugin.layout }
+                    : null,
+                });
+
+                if (pinning.applyName !== null) setName(pinning.applyName);
                 setDescription(data.description);
                 setModel(data.model || "");
                 setAllowedTools(data.allowedTools || "");
@@ -341,14 +408,14 @@ export function useCreateSkill({ onCreated, resolveAiConfigOverride }: UseCreate
                 aiMetaRef.current = meta;
                 setMode("manual");
 
-                // Apply suggested plugin from backend
-                // Contract: suggestedPlugin: { plugin, layout, confidence, reason } | null
-                if (data.suggestedPlugin && typeof data.suggestedPlugin === "object" && data.suggestedPlugin.plugin) {
-                  const sp = data.suggestedPlugin as { plugin: string; layout?: 1 | 2; confidence?: string; reason?: string };
+                // Apply suggested plugin from backend — ONLY when the user
+                // has not already pinned a destination (the helper answers
+                // that in `applySuggestedPlugin`).
+                if (pinning.applySuggestedPlugin && pinning.suggestedPluginValue) {
+                  const sp = pinning.suggestedPluginValue;
                   const allPlugins = layout?.detectedLayouts.flatMap((d) => d.existingPlugins) ?? [];
                   if (allPlugins.includes(sp.plugin)) {
                     setPlugin(sp.plugin);
-                    // Use layout from the suggestion if provided, otherwise scan
                     if (sp.layout && (sp.layout === 1 || sp.layout === 2)) {
                       setSelectedLayout(sp.layout);
                     } else {
@@ -364,8 +431,15 @@ export function useCreateSkill({ onCreated, resolveAiConfigOverride }: UseCreate
                     setPlugin("__new__");
                     setNewPlugin(sp.plugin);
                   }
-                } else if (selectedLayout === 3 && pluginLayoutInfo) {
-                  // Fallback: show plugin recommendation if on layout 3
+                } else if (
+                  !pinning.applySuggestedPlugin &&
+                  pluginRef.current.trim().length === 0 &&
+                  newPluginRef.current.trim().length === 0 &&
+                  selectedLayout === 3 &&
+                  pluginLayoutInfo
+                ) {
+                  // Fallback: show plugin recommendation if user is on
+                  // layout 3 AND has no pinned plugin AND no suggestion arrived.
                   setShowPluginRecommendation(true);
                 }
 

--- a/src/eval-ui/src/pages/CreateSkillPage.tsx
+++ b/src/eval-ui/src/pages/CreateSkillPage.tsx
@@ -612,8 +612,11 @@ export function CreateSkillPage() {
                   disabled={!sk.aiPrompt.trim()}
                   className="px-6 py-2.5 rounded-lg text-[13px] font-medium transition-all duration-150 flex items-center gap-2"
                   style={{
-                    background: !sk.aiPrompt.trim() ? "var(--surface-3)" : "var(--purple)",
-                    color: !sk.aiPrompt.trim() ? "var(--text-tertiary)" : "var(--color-paper)",
+                    // 0703 follow-up: primary CTA uses --color-action (blue)
+                    // to match the modal's Continue / Create buttons. Old
+                    // --purple was too light and read as disabled.
+                    background: !sk.aiPrompt.trim() ? "var(--surface-3)" : "var(--color-action, #2F5B8E)",
+                    color: !sk.aiPrompt.trim() ? "var(--text-tertiary)" : "var(--color-action-ink, #FFFFFF)",
                     cursor: !sk.aiPrompt.trim() ? "not-allowed" : "pointer",
                   }}
                 >
@@ -978,8 +981,11 @@ export function CreateSkillPage() {
                   disabled={sk.creating || !sk.name || !sk.description}
                   className="px-5 py-2.5 rounded-lg text-[13px] font-medium transition-all duration-150"
                   style={{
-                    background: sk.creating || !sk.name || !sk.description ? "var(--surface-3)" : "var(--accent)",
-                    color: sk.creating || !sk.name || !sk.description ? "var(--text-tertiary)" : "var(--color-paper)",
+                    // 0703 follow-up: align primary CTAs on the blue action
+                    // color. `--accent` was rendering too light to read as
+                    // enabled vs disabled at a glance.
+                    background: sk.creating || !sk.name || !sk.description ? "var(--surface-3)" : "var(--color-action, #2F5B8E)",
+                    color: sk.creating || !sk.name || !sk.description ? "var(--text-tertiary)" : "var(--color-action-ink, #FFFFFF)",
                     cursor: sk.creating || !sk.name || !sk.description ? "not-allowed" : "pointer",
                     opacity: sk.creating ? 0.7 : 1,
                   }}


### PR DESCRIPTION
## Summary

Four additional fixes on top of the 0703 hotfix ([#119](https://github.com/anton-abyzov/vskill/pull/119)), all reported during a fresh round of user testing.

### Fixes

1. **Page takeover was too aggressive** — `/#/create` route replaced the whole Studio layout, stripping the TopRail, ⌘K, project picker, and sidebar. Users felt teleported to a standalone page with no escape hatches. Now `CreateSkillPage` renders in the `main` slot of `StudioLayout` via a conditional `mainContent`, preserving all chrome. [App.tsx]
2. **Primary-action buttons looked disabled** — "Generate Skill" (AI mode) and "Create Skill" (manual mode) used `--purple` / `--accent`, both too light against the dark surface to read as "enabled". Swapped both to `--color-action` (the same blue the modal's Continue / Create buttons use) so enabled/disabled states are obvious. [CreateSkillPage.tsx]
3. **AI silently overrode user-pinned placement** — Entering the page via `?mode=new-plugin&pluginName=test-plugin&skillName=test-plugin-skill` should stick. Previously `data.name` and `data.suggestedPlugin` from the AI response clobbered the URL-supplied values (`test-plugin-skill` → `task-skill-announcer`, `test-plugin` → `frontend`). Extracted a pure helper `decideGenerationPinning()` that leaves user-pinned fields alone and only applies the AI's suggestion when the user hasn't chosen anything. 7 new unit tests cover every pin/unpin combination. [useCreateSkill.ts + test]
4. **`plugin.json` scaffold drifted from docs** — Per [plugins-reference](https://code.claude.com/docs/en/plugins-reference#plugin-manifest-schema), `author` is an object `{ name, email?, url? }`, and `version` should be omitted for new plugins so Claude Code uses the git SHA (hardcoded `"0.1.0"` is a "forgot to bump" footgun). Scaffold now emits `{ name, description, author: { name: "" } }`. [authoring-routes.ts]

### Test plan

- [x] 7 new unit tests for `decideGenerationPinning()` — all green
- [x] Existing `authoring-routes` suite updated: asserts `version` is undefined + `author: { name: "" }` shape — all green
- [x] 310/310 tests green across the full changed-files suite
- [x] Preview-verified live: `/#/create?...` keeps TopRail + ⌘K + brand visible; Generate Skill button is blue (`rgb(74,130,200)` = `--color-action`); URL-supplied `skillName=test-plugin-skill` survives navigation

### Research

Background subagent pulled https://code.claude.com/docs/en/plugins + plugins-reference + plugin-marketplaces; report in commit message points at the manifest schema + anti-patterns (paths under `.claude-plugin/`, hardcoded `version`, bare string `author`).