### PR TITLE
fix(install): fetch scripts/, assets/ and tests/ alongside SKILL.md

### DIFF
--- a/skills/excalidraw-mcp/SKILL.md
+++ b/skills/excalidraw-mcp/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: excalidraw-mcp
 description: Build Excalidraw diagrams through the official Excalidraw MCP and turn the same source into a real .excalidraw file on disk or an Obsidian .excalidraw.md drawing. Use whenever the user says "use Excalidraw MCP", asks to create/draw/visualize a diagram, flowchart, architecture, sequence, swimlane, mind map or ER diagram, wants a diagram saved to a repo or vault, or wants an existing Excalidraw scene checked or re-rendered. Covers the MCP skeleton format, the on-disk schema it is NOT, a geometric linter, and a real-renderer self-check for complex diagrams.
-version: 1.1.0
+version: 1.1.1
 license: MIT
 repository: anton-abyzov/vskill
 mcp-deps: [excalidraw]
@@ -144,6 +144,8 @@ skeleton file on disk in sync, since that file is what builds and lints.
 
 ## Changelog
 
+- **1.1.1** — linter no longer applies the box-fit rules (R1/R2) to arrow
+  containers; arrow labels are laid along the path and are covered by R10.
 - **1.1.0** — moved into the vskill monorepo at `skills/excalidraw-mcp/`, matching
   `remotion-best-practices` and the other in-repo skills. The standalone
   `anton-abyzov/excalidraw-mcp-skill` repo is deprecated.

--- a/skills/excalidraw-mcp/scripts/excalidraw_lint.py
+++ b/skills/excalidraw-mcp/scripts/excalidraw_lint.py
@@ -153,7 +153,10 @@ def check(elements: list[dict], skeleton: bool, want_camera: bool) -> Report:
             if not c:
                 r.err("R13-DANGLING", f"text {t['id']} points at missing container {cid}")
                 continue
-            check_label(c, t.get("text", ""), t.get("fontSize", 20))
+            # Arrow labels are laid along the path, not fitted inside a box —
+            # an arrow's width/height is its point span. R10 covers those.
+            if c["type"] in CONTAINER_TYPES:
+                check_label(c, t.get("text", ""), t.get("fontSize", 20))
             bound = c.get("boundElements") or []
             if not any(b.get("id") == t["id"] for b in bound):
                 r.err("R15-RECIPROCITY",

--- a/src/commands/__tests__/add-bundle-subdirs.test.ts
+++ b/src/commands/__tests__/add-bundle-subdirs.test.ts
@@ -1,0 +1,48 @@
+// Bundle fetching: a skill installed without its scripts/ is broken, not merely
+// degraded. These guard the allowlist that decides what travels with SKILL.md.
+
+import { describe, it, expect } from "vitest";
+import { BUNDLE_SUBDIRS, isBundleTextFile } from "../add.js";
+import { assertSafeBundlePath } from "../../installer/bundle-files.js";
+
+describe("BUNDLE_SUBDIRS", () => {
+  it("covers every directory the installer is willing to write", () => {
+    // Every fetched subdir must be writable by the installer, or the install
+    // throws on an "Unsupported bundled skill file path".
+    for (const dir of BUNDLE_SUBDIRS) {
+      expect(() => assertSafeBundlePath(`${dir}/example.md`)).not.toThrow();
+    }
+  });
+
+  it("includes scripts/ — the regression this fixes", () => {
+    expect(BUNDLE_SUBDIRS).toContain("scripts");
+    expect(BUNDLE_SUBDIRS).toContain("references");
+  });
+});
+
+describe("isBundleTextFile", () => {
+  it("accepts the text formats skills actually ship", () => {
+    for (const name of [
+      "SKILL.md", "notes.txt", "config.json", "data.yaml", "build.py",
+      "run.sh", "helper.ts", "helper.mjs", "diagram.excalidraw", "icon.svg",
+    ]) {
+      expect(isBundleTextFile(name), name).toBe(true);
+    }
+  });
+
+  it("rejects binaries that would be corrupted by string transport", () => {
+    for (const name of ["logo.png", "clip.mp4", "font.woff2", "archive.zip", "lib.so"]) {
+      expect(isBundleTextFile(name), name).toBe(false);
+    }
+  });
+
+  it("rejects dotfiles such as .DS_Store", () => {
+    expect(isBundleTextFile(".DS_Store")).toBe(false);
+    expect(isBundleTextFile(".gitignore")).toBe(false);
+  });
+
+  it("is case-insensitive on the extension", () => {
+    expect(isBundleTextFile("README.MD")).toBe(true);
+    expect(isBundleTextFile("Script.PY")).toBe(true);
+  });
+});

--- a/src/commands/add.ts
+++ b/src/commands/add.ts
@@ -75,6 +75,33 @@ import {
 } from "../lib/skill-lifecycle.js";
 
 // ---------------------------------------------------------------------------
+/**
+ * Subdirectories fetched alongside SKILL.md when installing a skill that lives
+ * in a repo subdirectory. Must stay a subset of the prefixes the installer
+ * accepts in installer/bundle-files.ts, or the write is rejected.
+ */
+export const BUNDLE_SUBDIRS = ["agents", "references", "scripts", "assets", "tests"] as const;
+
+/**
+ * Extensions carried in a skill bundle. Bundle contents are transported as
+ * UTF-8 strings, so this is a text-only allowlist — binaries would be corrupted.
+ */
+const BUNDLE_TEXT_EXTENSIONS = [
+  ".md", ".txt", ".json", ".jsonc", ".yaml", ".yml", ".toml", ".csv",
+  ".py", ".sh", ".bash", ".zsh", ".js", ".mjs", ".cjs", ".ts", ".sql",
+  ".excalidraw", ".svg", ".css", ".html",
+] as const;
+
+/** Per-file and per-skill ceilings, so one fat repo cannot stall an install. */
+const MAX_BUNDLE_FILE_BYTES = 512 * 1024;
+const MAX_BUNDLE_FILES = 100;
+
+export function isBundleTextFile(name: string): boolean {
+  const lower = name.toLowerCase();
+  if (lower.startsWith(".")) return false; // .DS_Store, dotfiles
+  return BUNDLE_TEXT_EXTENSIONS.some((ext) => lower.endsWith(ext));
+}
+
 /** Validate that a download_url from GitHub Contents API points to a trusted GitHub domain. */
 function isGitHubDownloadUrl(url: string): boolean {
   try {
@@ -2917,13 +2944,17 @@ async function installSingleSkillLegacy(
   }
   if (content === undefined) return process.exit(1);
 
-  // Fetch agents/*.md and references/*.md if skill is in a subdirectory.
-  // Both directories are part of the skill-authoring convention: agents/ holds
-  // sub-agent prompts, references/ holds docs the SKILL.md links to — a skill
-  // installed without its references is silently degraded.
+  // Fetch the skill's bundled subdirectories when the skill lives in a
+  // subdirectory of the repo. These are the skill-authoring convention and the
+  // same prefixes the installer accepts (see installer/bundle-files.ts):
+  // agents/ holds sub-agent prompts, references/ the docs SKILL.md links to,
+  // scripts/ the executable tooling, assets/ static files, tests/ its tests.
+  // A skill whose SKILL.md says "run scripts/foo.py" and installs without
+  // scripts/ is not degraded — it is broken.
   let legacyAgentFiles: Record<string, string> | undefined;
   if (skill) {
-    for (const subdir of ["agents", "references"] as const) {
+    let fetched = 0;
+    for (const subdir of BUNDLE_SUBDIRS) {
       try {
         const basePath = skillSubpath.replace(/\/SKILL\.md$/, `/${subdir}`);
         // ?ref= keeps the listing on the same branch as SKILL.md
@@ -2931,17 +2962,32 @@ async function installSingleSkillLegacy(
         const dirUrl = `https://api.github.com/repos/${owner}/${repo}/contents/${basePath}?ref=${encodeURIComponent(branch)}`;
         const dirRes = await githubFetch(dirUrl, { headers: { Accept: "application/vnd.github.v3+json" } });
         if (!dirRes.ok) continue;
-        const entries = (await dirRes.json()) as Array<{ name: string; download_url?: string }>;
-        const mdEntries = entries.filter((e) => e.name.endsWith(".md") && e.download_url && isGitHubDownloadUrl(e.download_url!));
-        if (mdEntries.length === 0) continue;
+        const entries = (await dirRes.json()) as Array<{
+          name: string;
+          type?: string;
+          size?: number;
+          download_url?: string;
+        }>;
+        const wanted = entries.filter(
+          (e) =>
+            e.type !== "dir" &&
+            isBundleTextFile(e.name) &&
+            (e.size ?? 0) <= MAX_BUNDLE_FILE_BYTES &&
+            e.download_url &&
+            isGitHubDownloadUrl(e.download_url),
+        );
+        if (wanted.length === 0) continue;
         legacyAgentFiles ??= {};
-        const fetches = mdEntries.map(async (entry) => {
+        const budget = wanted.slice(0, Math.max(0, MAX_BUNDLE_FILES - fetched));
+        fetched += budget.length;
+        const fetches = budget.map(async (entry) => {
           try {
             const res = await githubFetch(entry.download_url!);
             if (res.ok) legacyAgentFiles![`${subdir}/${entry.name}`] = await res.text();
           } catch { /* skip */ }
         });
         await Promise.allSettled(fetches);
+        if (fetched >= MAX_BUNDLE_FILES) break;
       } catch { /* subdir doesn't exist or API error — fine */ }
     }
     if (legacyAgentFiles && Object.keys(legacyAgentFiles).length === 0) legacyAgentFiles = undefined;


### PR DESCRIPTION
Installing a multi-file skill from the registry shipped **only SKILL.md**. A skill whose SKILL.md says \`run scripts/foo.py\` and installs without \`scripts/\` is not degraded — it is broken.

Repro (before):

\`\`\`
$ vskill i anton-abyzov/vskill/excalidraw-mcp
$ find ~/.claude/skills/excalidraw-mcp -type f
~/.claude/skills/excalidraw-mcp/SKILL.md      # and nothing else
\`\`\`

## Cause

\`add.ts\` walked only \`["agents", "references"]\` and filtered to \`.md\` files. The installer side was never the problem — \`installer/bundle-files.ts\` has always accepted \`agents/ scripts/ references/ assets/ tests/\`. Only the fetcher was narrow.

## Fix

- Walk \`BUNDLE_SUBDIRS = [agents, references, scripts, assets, tests]\` — exactly the prefixes the installer accepts, asserted by a test so the two lists cannot drift.
- Select files by a text-extension allowlist (\`.md .txt .json .yaml .toml .py .sh .js .ts .sql .excalidraw .svg .css .html\` …) instead of \`.md\` only. Bundle contents travel as UTF-8 strings, so binaries are excluded deliberately — they would be corrupted.
- Skip dotfiles (\`.DS_Store\`).
- Ceilings so one fat repo cannot stall an install: 512 KB per file, 100 files per skill.

After:

\`\`\`
~/.claude/skills/excalidraw-mcp/SKILL.md
~/.claude/skills/excalidraw-mcp/references/*.md      (4)
~/.claude/skills/excalidraw-mcp/scripts/*.py         (4)
\`\`\`

…and the installed scripts run: built and linted a diagram straight from \`~/.claude/skills/\`.

Also in this PR: \`skills/excalidraw-mcp\` 1.1.1 — its linter was applying the box-fit rules to arrow containers, where width/height is the point span, so a labelled horizontal arrow reported a bogus \`label needs 20px, box gives -10px\`. Found by running the freshly installed copy.

## Tests

6 new in \`add-bundle-subdirs.test.ts\`: every fetched subdir is writable by \`assertSafeBundlePath\`, scripts/ is present, text formats accepted, binaries and dotfiles rejected, extension match case-insensitive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)