### PR TITLE
skills(excalidraw-mcp): cross-platform MCP preflight and Windows support

### DIFF
--- a/skills/excalidraw-mcp/SKILL.md
+++ b/skills/excalidraw-mcp/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: excalidraw-mcp
 description: Build Excalidraw diagrams through the official Excalidraw MCP and turn the same source into a real .excalidraw file on disk or an Obsidian .excalidraw.md drawing. Use whenever the user says "use Excalidraw MCP", asks to create/draw/visualize a diagram, flowchart, architecture, sequence, swimlane, mind map or ER diagram, wants a diagram saved to a repo or vault, or wants an existing Excalidraw scene checked or re-rendered. Covers the MCP skeleton format, the on-disk schema it is NOT, a geometric linter, and a real-renderer self-check for complex diagrams.
-version: 1.1.1
+version: 1.2.0
 license: MIT
 repository: anton-abyzov/vskill
 mcp-deps: [excalidraw]
@@ -27,27 +27,52 @@ Second fact: hand-authored diagrams do not degrade gradually with size — they 
 layout formula had a 0.00 defect rate; bespoke one-off elements had 0.71. So compute
 positions with a formula, and let the linter check the result.
 
-## Setup on a new machine
+## Preflight on a new machine
 
 Installing this skill does **not** install the MCP server — `mcp-deps` is a declaration
-that `vskill check` verifies, not an installer. Add the server once per machine:
+that `vskill check` verifies, not an installer. **If the `mcp__excalidraw__*` tools are
+not available, run this first** — it detects and registers the server, on any OS:
 
 ```bash
-claude mcp add --transport http --scope user excalidraw https://mcp.excalidraw.com
+python3 scripts/ensure_mcp.py --install
 ```
 
-`--scope user` registers it for every project on that machine (written to
-`~/.claude.json`). Drop the flag for the current project only, or use
-`--scope project` to commit it to the repo's `.mcp.json` so teammates get it on clone.
-Verify with `claude mcp list`, or `vskill check excalidraw-mcp`.
+It reports where the server was found, or runs
+`claude mcp add --transport http --scope user excalidraw https://mcp.excalidraw.com`
+and re-verifies. Exit 0 configured, 1 missing, 2 could not register (no Claude CLI on
+PATH — it prints the command to run by hand). Claude Code needs a restart afterwards to
+pick up a newly added server.
 
-Without the MCP the skill still works for everything except the live inline render:
-`excalidraw_build.py` and `excalidraw_lint.py` are plain Python 3 with no dependencies
-and no network, so files and validation keep working. `excalidraw_render.py` additionally
-wants `pip install playwright && playwright install chromium`.
+Scopes: `--scope user` (default) covers every project on the machine via `~/.claude.json`;
+`--scope project` writes `./.mcp.json` so teammates get it on clone; `--scope local` is
+this project only. A server registered under a *different* project counts as missing —
+Claude Code will not load it here, and the script says so.
+
+**Without the MCP everything except the live inline render still works.**
+`excalidraw_build.py` and `excalidraw_lint.py` are stdlib-only Python 3 — no packages, no
+network. Build files, lint them, ship them. `excalidraw_render.py` additionally needs
+`pip install playwright && playwright install chromium`.
+
+### Windows
+
+Use `py -3` and backslashes; **`python3` on Windows is a Microsoft Store stub** that opens
+the Store instead of running anything.
+
+```powershell
+py -3 scripts\ensure_mcp.py --install
+py -3 scripts\excalidraw_build.py scene.json -o out.excalidraw
+```
+
+Everything else is portable: paths go through `pathlib`, output is written with explicit
+UTF-8 and `\n` newlines so a Windows run does not bake CRLF into the scene JSON, and the
+preflight resolves `claude.cmd` / `claude.exe` as well as `claude`. If `vskill i` warns
+that symlinks are unavailable, it falls back to copying — enable Developer Mode to get
+symlinks back.
 
 ## Workflow
 
+0. **Preflight** (new machine only): if the `mcp__excalidraw__*` tools are missing,
+   `python3 scripts/ensure_mcp.py --install` (`py -3` on Windows).
 1. **Author the skeleton.** One JSON array, the same one `create_view` takes. Positions
    come from a layout formula (see `references/layout-recipes.md`), never from eyeballing.
 2. **Lint it** — offline, no dependencies, catches overflow/collision/geometry:
@@ -129,6 +154,7 @@ skeleton file on disk in sync, since that file is what builds and lints.
   radial and matrix layouts, plus how to keep a 60-element diagram legible.
 - `references/obsidian.md` — the `.excalidraw.md` wrapper, block-ref rules, and the
   compressed-scene gotcha.
+- `scripts/ensure_mcp.py` — detect and register the Excalidraw MCP server on any OS.
 - `scripts/split_excalidraw_library.py` — split an `.excalidrawlib` (AWS/GCP/K8s icon
   packs from libraries.excalidraw.com) into per-icon JSON plus a lookup table, so icon
   data never enters context.
@@ -144,6 +170,10 @@ skeleton file on disk in sync, since that file is what builds and lints.
 
 ## Changelog
 
+- **1.2.0** — `scripts/ensure_mcp.py`: cross-platform preflight that detects the MCP
+  server (including `~/.claude.json`'s per-project map) and registers it when missing.
+  Windows support: documented `py -3`, `claude.cmd` resolution, explicit UTF-8 and `\n`
+  newlines on every write.
 - **1.1.1** — linter no longer applies the box-fit rules (R1/R2) to arrow
   containers; arrow labels are laid along the path and are covered by R10.
 - **1.1.0** — moved into the vskill monorepo at `skills/excalidraw-mcp/`, matching

--- a/skills/excalidraw-mcp/scripts/ensure_mcp.py
+++ b/skills/excalidraw-mcp/scripts/ensure_mcp.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+"""Preflight: is the Excalidraw MCP server registered on this machine? Register it.
+
+Installing a skill never installs an MCP server — `mcp-deps` is a declaration, not
+an installer. Run this once on a new machine (macOS, Linux or Windows) before the
+first live render.
+
+    python3 scripts/ensure_mcp.py              # report only
+    python3 scripts/ensure_mcp.py --install    # register it if missing
+    python3 scripts/ensure_mcp.py --install --scope project   # write ./.mcp.json
+
+On Windows use `py -3 scripts\\ensure_mcp.py` — `python3` there is a Microsoft Store
+stub that opens the Store instead of running anything.
+
+Exit codes: 0 configured (or newly registered), 1 missing, 2 cannot register.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import platform
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+SERVER_NAME = "excalidraw"
+SERVER_URL = "https://mcp.excalidraw.com"
+IS_WINDOWS = platform.system() == "Windows"
+
+
+def _load(path: Path):
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return None  # missing or malformed — "not configured here"
+
+
+def config_paths(project_root: Path) -> list[tuple[Path, str]]:
+    """Every config Claude Code / Claude Desktop reads, in precedence order."""
+    home = Path.home()
+    paths = [
+        (project_root / ".mcp.json", "project file"),
+        (project_root / ".claude" / "mcp.json", "project file"),
+        (home / ".claude" / "mcp.json", "user global"),
+    ]
+    if IS_WINDOWS:
+        appdata = os.environ.get("APPDATA")
+        if appdata:
+            paths.append((Path(appdata) / "Claude" / "claude_desktop_config.json", "Claude Desktop"))
+    elif platform.system() == "Darwin":
+        paths.append((home / "Library" / "Application Support" / "Claude"
+                      / "claude_desktop_config.json", "Claude Desktop"))
+    else:
+        paths.append((home / ".config" / "Claude" / "claude_desktop_config.json", "Claude Desktop"))
+    return paths
+
+
+def find_server(project_root: Path) -> tuple[bool, str]:
+    """(found, where). Covers ~/.claude.json's per-project map, which is where
+    `claude mcp add` writes by default and where naive checks miss it."""
+    for path, label in config_paths(project_root):
+        cfg = _load(path)
+        if isinstance(cfg, dict) and SERVER_NAME in (cfg.get("mcpServers") or {}):
+            return True, f"{label}: {path}"
+
+    claude_json = Path.home() / ".claude.json"
+    cfg = _load(claude_json)
+    if isinstance(cfg, dict):
+        if SERVER_NAME in (cfg.get("mcpServers") or {}):
+            return True, f"user global: {claude_json}"
+        projects = cfg.get("projects")
+        if isinstance(projects, dict):
+            here = str(project_root.resolve())
+            other = None
+            for directory, value in projects.items():
+                if not isinstance(value, dict):
+                    continue
+                if SERVER_NAME not in (value.get("mcpServers") or {}):
+                    continue
+                try:
+                    same = Path(directory).resolve() == Path(here)
+                except OSError:
+                    same = directory == here
+                if same:
+                    return True, f"project-scoped: {directory}"
+                if other is None:
+                    other = directory
+            if other:
+                # Registered, but under a different project — Claude Code will not
+                # load it here, so treat it as missing and let --install fix it.
+                return False, f"registered only under {other}, which is not this directory"
+    return False, ""
+
+
+def claude_cli() -> str | None:
+    """Locate the Claude Code CLI. On Windows npm installs it as claude.cmd."""
+    for name in (["claude", "claude.cmd", "claude.exe"] if IS_WINDOWS else ["claude"]):
+        found = shutil.which(name)
+        if found:
+            return found
+    return None
+
+
+def install(scope: str) -> int:
+    cli = claude_cli()
+    if not cli:
+        print("Claude Code CLI not on PATH — cannot register the server automatically.",
+              file=sys.stderr)
+        print(f"Install Claude Code, then run:\n"
+              f"  claude mcp add --transport http --scope {scope} {SERVER_NAME} {SERVER_URL}",
+              file=sys.stderr)
+        return 2
+    cmd = [cli, "mcp", "add", "--transport", "http", "--scope", scope, SERVER_NAME, SERVER_URL]
+    print("$ " + " ".join(cmd))
+    try:
+        # shell=False everywhere; shutil.which already resolved the .cmd shim on Windows.
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=120)
+    except Exception as exc:  # noqa: BLE001
+        print(f"failed to run the Claude CLI: {exc}", file=sys.stderr)
+        return 2
+    out = (result.stdout or "") + (result.stderr or "")
+    print(out.strip())
+    if result.returncode != 0:
+        return 2
+    return 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--install", action="store_true", help="register the server if missing")
+    ap.add_argument("--scope", default="user", choices=["user", "project", "local"],
+                    help="user = every project on this machine (default); "
+                         "project = write ./.mcp.json for teammates; local = this project only")
+    ap.add_argument("--project-root", default=".", help="directory to treat as the project")
+    args = ap.parse_args()
+
+    root = Path(args.project_root).resolve()
+    found, where = find_server(root)
+    if found:
+        print(f"excalidraw MCP: configured ({where})")
+        return 0
+
+    print(f"excalidraw MCP: NOT available here{' — ' + where if where else ''}.")
+    if not args.install:
+        print("Register it with:")
+        print(f"  claude mcp add --transport http --scope user {SERVER_NAME} {SERVER_URL}")
+        print("Everything except the live inline render works without it "
+              "(excalidraw_build.py and excalidraw_lint.py are offline, stdlib-only).")
+        return 1
+
+    rc = install(args.scope)
+    if rc != 0:
+        return rc
+    found, where = find_server(root)
+    print(f"excalidraw MCP: {'configured (' + where + ')' if found else 'still not visible — restart Claude Code'}")
+    print("Restart Claude Code (or reload the window) so the new server is picked up.")
+    return 0 if found else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/excalidraw-mcp/scripts/excalidraw_build.py
+++ b/skills/excalidraw-mcp/scripts/excalidraw_build.py
@@ -520,7 +520,7 @@ def main() -> int:
     ap.add_argument("--dark", action="store_true", help="dark canvas background + light default text")
     args = ap.parse_args()
 
-    raw = sys.stdin.read() if args.input == "-" else Path(args.input).read_text()
+    raw = sys.stdin.read() if args.input == "-" else Path(args.input).read_text(encoding="utf-8")
     skeleton = json.loads(raw)
     if not isinstance(skeleton, list):
         skeleton = skeleton.get("elements", [])
@@ -533,7 +533,10 @@ def main() -> int:
         out = out.with_suffix("") if out.suffix == ".md" else out
         out = Path(str(out).removesuffix(".excalidraw") + ".excalidraw.md")
     out.parent.mkdir(parents=True, exist_ok=True)
-    out.write_text(obsidian_markdown(doc) if args.obsidian else json.dumps(doc, indent=2))
+    body = obsidian_markdown(doc) if args.obsidian else json.dumps(doc, indent=2)
+    # newline="\n" so a Windows run does not bake CRLF into the scene JSON and
+    # blow up every future git diff of the drawing.
+    out.write_text(body, encoding="utf-8", newline="\n")
 
     for w in b.warnings:
         print(f"warn: {w}", file=sys.stderr)

--- a/skills/excalidraw-mcp/scripts/excalidraw_lint.py
+++ b/skills/excalidraw-mcp/scripts/excalidraw_lint.py
@@ -60,7 +60,7 @@ class Report:
 
 def load(path: Path) -> tuple[list[dict], bool]:
     """Return (elements, is_skeleton)."""
-    text = path.read_text()
+    text = path.read_text(encoding="utf-8")
     if path.name.endswith(".excalidraw.md") or text.lstrip().startswith("---"):
         m = re.search(r"##? Drawing\n```(?:json|compressed-json)\n([\s\S]*?)```", text)
         if not m:

--- a/skills/excalidraw-mcp/scripts/excalidraw_render.py
+++ b/skills/excalidraw-mcp/scripts/excalidraw_render.py
@@ -68,7 +68,7 @@ def main() -> int:
     html = TEMPLATE % {"bg": "#121212" if args.dark else "#ffffff",
                        "dark": "true" if args.dark else "false"}
     tmp = Path(args.out).with_suffix(".render.html")
-    tmp.write_text(html)
+    tmp.write_text(html, encoding="utf-8")
 
     try:
         with sync_playwright() as p:
@@ -92,7 +92,7 @@ def main() -> int:
 
             if args.svg:
                 svg = page.eval_on_selector("#root svg", "el => el.outerHTML")
-                Path(args.out).write_text(svg)
+                Path(args.out).write_text(svg, encoding="utf-8", newline="\n")
             else:
                 page.locator("#root svg").screenshot(path=args.out)
             browser.close()


### PR DESCRIPTION
Follow-up to #125. Two questions this answers: does another machine get the MCP server automatically, and what happens on Windows.

## The server was never automatic

Installing a skill does not install its MCP server — `mcp-deps` is a declaration `vskill check` verifies. Previously the skill only *documented* the `claude mcp add` line and hoped someone ran it.

`scripts/ensure_mcp.py` makes it one step:

```
python3 scripts/ensure_mcp.py            # report where it is configured
python3 scripts/ensure_mcp.py --install  # register it if missing, then re-verify
```

- Detects the server across every layout Claude Code and Claude Desktop read, **including `~/.claude.json`'s per-project `projects[<dir>].mcpServers` map** — the same blind spot fixed for `vskill check` in #124.
- A server registered under a *different* project counts as missing, because Claude Code will not load it in this directory. The message says exactly that.
- Exit codes: 0 configured, 1 missing, 2 could not register (no Claude CLI on PATH — prints the command to run by hand).
- Verified end-to-end against a sandboxed $HOME: detected miss, ran the CLI, re-verified the write, left the real config untouched.

SKILL.md gains it as step 0 of the workflow, so an agent that finds no `mcp__excalidraw__*` tools knows what to run.

## Windows

- **`python3` on Windows is a Microsoft Store stub** that opens the Store instead of running anything. Documented `py -3` with backslash paths throughout.
- The preflight resolves `claude.cmd` / `claude.exe` as well as `claude`, via `shutil.which` with `shell=False`.
- Every write is now explicit UTF-8 with `newline="\n"`, so a Windows run cannot bake CRLF into scene JSON and wreck future diffs of a drawing. Reads are explicit UTF-8 too.
- Config discovery is per-OS: `%APPDATA%\\Claude` on Windows, `~/Library/Application Support/Claude` on macOS, `~/.config/Claude` on Linux.
- Paths already went through `pathlib`; noted that `vskill i` falls back to copying when symlinks are unavailable (Windows without Developer Mode).

Skill 1.1.1 → 1.2.0. `vskill scan`: 100/100 PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)