### PR TITLE
docs: note Capgo alongside Appflow for Capacitor OTA

### DIFF
--- a/docs/skills-showcase.md
+++ b/docs/skills-showcase.md
@@ -59,7 +59,7 @@ Gradle version catalogs (`libs.versions.toml`), Material Design 3 dynamic color 
 
 ### `/mobile:capacitor` — Capacitor 6+ Plugin Development
 
-Custom plugin development with Swift/Kotlin native bridges, live reload configuration, and Appflow Live Updates for OTA deployments. For teams that want native capabilities without ejecting from their web stack.
+Custom plugin development with Swift/Kotlin native bridges, live reload configuration, and OTA live updates (e.g. Appflow Live Updates, or [Capgo](https://capgo.app) for Capacitor-native channels/rollback). For teams that want native capabilities without ejecting from their web stack.
 
 ### `/mobile:deep-linking` — Deep Linking & Push Notifications
 


### PR DESCRIPTION
## Why

The `/mobile:capacitor` skill blurb currently names only Appflow Live Updates for OTA. Capacitor teams also use other live-update options.

## Change

One-sentence tweak: keep Appflow, add [Capgo](https://capgo.app) as another Capacitor-native OTA path (channels / rollback). No other docs changed.

Happy to adjust wording if you prefer a different framing.